### PR TITLE
rpc: document why exec.Command(bin, args...) has no injection surface

### DIFF
--- a/rpc.go
+++ b/rpc.go
@@ -123,6 +123,16 @@ func (c *RPCClient) Start() error {
 	if c.sessionPath != "" {
 		args = append(args, "--session", c.sessionPath)
 	}
+
+	// Safety note (CWE-94 / dangerous-exec-command scan in #38):
+	// exec.Command does NOT invoke a shell, so args are passed verbatim as
+	// argv entries and can never inject shell syntax. Neither the binary nor
+	// the argument list is derived from untrusted input: c.bin defaults to
+	// "pi" and is not configurable at runtime, and args are built only from
+	// operator-controlled config (model, extension path, session path) set at
+	// construction time. Inbound XMPP message content is delivered to pi over
+	// its stdin via the RPC protocol and never reaches exec.Command. There is
+	// therefore no code-injection surface here.
 	cmd := exec.Command(c.bin, args...)
 	cmd.Dir = c.cwd
 	cmd.Env = append(os.Environ(), c.env...)


### PR DESCRIPTION
Closes #38

## What

The scan flagged `exec.Command(c.bin, args...)` in `rpc.go` as CWE-94 (code injection). This PR resolves it by documenting the safety reasoning directly above the call — no functional change.

## Why the finding is a false positive

1. **No shell involved.** `exec.Command` executes the binary directly with args as separate argv entries; it never invokes a shell, so shell metacharacters in args cannot inject anything. (The suggested fix's 'reject `|&;`$\<>"`' check guards against a threat that doesn't exist here.)
2. **Binary is not attacker-controlled.** `bridge.go` calls `NewRPCClient("", ...)`, so `c.bin` always defaults to `"pi"` from PATH — it is not runtime-configurable.
3. **Args are operator config, not message content.** args are built only from `model`, `extPath` (a temp file we create), and `sessionPath`. Inbound XMPP message content is written to pi over stdin via the RPC protocol and never reaches `exec.Command`.

## Why not the suggested fix

The proposed allowlist (`/usr/bin/rsync`, `/usr/bin/scp`) names binaries this project never executes and would reject the actual `pi` binary, breaking the bridge. Applying it verbatim would be harmful.

## Verification

- `gofmt` clean, `go build ./...` OK, `go vet ./...` OK, `go test ./...` OK