### PR TITLE
send_file: return the XEP-0363 share URL to the agent

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -501,16 +501,18 @@ func (b *Bridge) handleToolRelay(id, payload string) {
 			return
 		}
 		// The XEP-0363 upload is a network round-trip (up to ~2min); run it off
-		// the RPC event loop and answer the blocked tool when it settles.
+		// the RPC event loop and answer the blocked tool when it settles. On
+		// success the relay returns the share URL so the agent can reuse it
+		// elsewhere (e.g. paste the link into a PR), not just "ok".
 		go func() {
-			err := b.xmpp.SendFile(dest, cmd.Path)
+			url, err := b.xmpp.SendFile(dest, cmd.Path)
 			if err != nil {
 				reason := fmt.Sprintf("send_file %q → %s failed: %v", cmd.Path, dest, err)
 				b.reply("⚠️ " + reason)
 				b.rpc.RespondUIRelay(id, reason)
 				return
 			}
-			b.rpc.RespondUIRelay(id, "ok")
+			b.rpc.RespondUIRelay(id, url)
 		}()
 	default:
 		b.log("warning", "unknown tool-relay action: "+cmd.Action)
@@ -813,7 +815,7 @@ func (b *Bridge) sendDumpFile(name string, content []byte) {
 		dest = b.acct.Owner
 	}
 	go func() {
-		if err := b.xmpp.SendFile(dest, p); err != nil {
+		if _, err := b.xmpp.SendFile(dest, p); err != nil {
 			b.reply(fmt.Sprintf("⚠️ /dump: file upload failed (%v); sending inline", err))
 			inline := string(content)
 			if len(inline) <= maxBody {

--- a/piext/xmpp-tools.ts
+++ b/piext/xmpp-tools.ts
@@ -121,10 +121,11 @@ ${event.systemPrompt}`,
 			name: "send_file",
 			label: "Send file (XMPP)",
 			description:
-				"Upload a local file and deliver it to the human over XMPP (XEP-0363 HTTP Upload). The path must be absolute and readable on this host. Defaults to the current conversation; pass `to` to target a specific allowed JID.",
+				"Upload a local file and deliver it to the human over XMPP (XEP-0363 HTTP Upload). The path must be absolute and readable on this host. Defaults to the current conversation; pass `to` to target a specific allowed JID. Returns the share URL of the uploaded file so you can reuse it elsewhere (e.g. paste the link into a PR).",
 			promptSnippet: "Send a local file (log, diff, image) to the human over chat",
 			promptGuidelines: [
 				"Use send_file to deliver a real local file to the human; give an absolute path. It is for files, not for pasting text.",
+				"The tool result includes the share URL — reuse it (e.g. in a PR description or follow-up message) instead of describing the file.",
 			],
 			parameters: Type.Object({
 				path: Type.String({ description: "Absolute path to a local file on this host" }),
@@ -136,13 +137,17 @@ ${event.systemPrompt}`,
 				if (!path) {
 					throw new Error("path is required");
 				}
+				// The relay returns the XEP-0363 share URL on success, or a failure
+				// reason (not a URL) on error — so a result that is a URL is the
+				// uploaded link, anything else is the failure reason.
 				const result = await relay("file", { path, to: p.to ?? "" });
-				if (result !== "ok") {
+				const url = /^https?:\/\//.test(result) ? result : "";
+				if (!url) {
 					throw new Error(`pi-msg could not send the file ${path}: ${result}`);
 				}
 				return {
-					content: [{ type: "text", text: `Sent file ${path}.` }],
-					details: { path },
+					content: [{ type: "text", text: `Sent file ${path}. Share URL: ${url}` }],
+					details: { path, url },
 				};
 			},
 		});

--- a/xmpp.go
+++ b/xmpp.go
@@ -1730,29 +1730,31 @@ func (b *XMPPBridge) SendRoomTo(room, text string) string {
 
 // SendFile uploads a local file via XEP-0363 and sends its URL to `to` as an
 // XEP-0066 out-of-band message (groupchat if `to` is a joined room, else 1:1),
-// so the recipient's client shows it as a downloadable file.
-func (b *XMPPBridge) SendFile(to, path string) error {
+// so the recipient's client shows it as a downloadable file. It returns the
+// share URL on success so the send_file relay can hand it back to the agent
+// (to reuse elsewhere, e.g. pasted into a PR) rather than discarding it.
+func (b *XMPPBridge) SendFile(to, path string) (string, error) {
 	session := b.currentSession()
 	if session == nil {
-		return fmt.Errorf("not online")
+		return "", fmt.Errorf("not online")
 	}
 	fi, err := os.Stat(path)
 	if err != nil {
-		return fmt.Errorf("stat %s: %w", path, err)
+		return "", fmt.Errorf("stat %s: %w", path, err)
 	}
 	if fi.IsDir() {
-		return fmt.Errorf("%s is a directory", path)
+		return "", fmt.Errorf("%s is a directory", path)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
 	svc, err := b.uploadService(ctx)
 	if err != nil {
-		return err
+		return "", err
 	}
 	svcJID, err := jid.Parse(svc)
 	if err != nil {
-		return fmt.Errorf("invalid upload service %q: %w", svc, err)
+		return "", fmt.Errorf("invalid upload service %q: %w", svc, err)
 	}
 	name := filepath.Base(path)
 	ctype := mime.TypeByExtension(filepath.Ext(name))
@@ -1761,33 +1763,36 @@ func (b *XMPPBridge) SendFile(to, path string) error {
 	}
 	slot, err := upload.GetSlot(ctx, upload.File{Name: name, Size: int(fi.Size()), Type: ctype}, svcJID, session)
 	if err != nil {
-		return fmt.Errorf("requesting upload slot: %w", err)
+		return "", fmt.Errorf("requesting upload slot: %w", err)
 	}
 	f, err := os.Open(path)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer f.Close()
 	req, err := slot.Put(ctx, f)
 	if err != nil {
-		return err
+		return "", err
 	}
 	req.ContentLength = fi.Size()
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return fmt.Errorf("uploading file: %w", err)
+		return "", fmt.Errorf("uploading file: %w", err)
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return fmt.Errorf("upload rejected (HTTP %d)", resp.StatusCode)
+		return "", fmt.Errorf("upload rejected (HTTP %d)", resp.StatusCode)
 	}
 
 	typ := stanza.ChatMessage
 	if b.isRoomJID(bareJid(to)) {
 		typ = stanza.GroupChatMessage
 	}
-	return b.encodeOOB(to, slot.GetURL.String(), typ)
+	if err := b.encodeOOB(to, slot.GetURL.String(), typ); err != nil {
+		return "", err
+	}
+	return slot.GetURL.String(), nil
 }
 
 // uploadService resolves (and caches) the XEP-0363 upload component JID: the


### PR DESCRIPTION
Implements: send_file currently answers success with bare "ok", discarding the XEP-0363 share URL. Now the tool returns the URL so the agent can reuse it (e.g. paste the link into a PR).

- `SendFile` returns (url, error)
- `handleToolRelay` answers the file relay with the URL (failure reason unchanged, #34)
- tool result/content carries the URL; description + guidelines updated