### PR TITLE
bridge: support ! as an alias for / on commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ sequenceDiagram
 | `/dump` (or `/dump pretty`) | send the session transcript to the owner — raw JSONL, or `pretty` for indented per-record JSON (no LLM turn) |
 | `/quit` (or `/exit`) | shut down the bridge and Pi |
 
+Every bridged command also works with a `!` prefix — `/new` and `!new` are
+interchangeable. ("/", "!") only matters for the owner: non-owners' messages
+are always treated as literal text.
+
 ## Configuration
 
 Create `~/.config/pi-msg/config.json` (override the path with `PI_MSG_CONFIG`), then

--- a/bridge.go
+++ b/bridge.go
@@ -671,7 +671,7 @@ func (b *Bridge) handleCanonical(text, origin, sender, reactTo, reactID string) 
 	if t == "" {
 		return
 	}
-	if strings.HasPrefix(t, "/") && b.handleCommand(t) {
+	if (strings.HasPrefix(t, "/") || strings.HasPrefix(t, "!")) && b.handleCommand(t) {
 		return
 	}
 	// A real prompt: point lifecycle/agent reactions at the message that drove it,
@@ -2217,8 +2217,11 @@ func extractText(content any) string {
 }
 
 // splitCommand splits "/name arg..." into a lowercased name and trimmed arg.
+// splitCommand splits "/name arg..." or "!name arg..." into a lowercased
+// name and trimmed arg. "!" is a full alias for "/" on bridged commands.
 func splitCommand(t string) (name, arg string) {
 	body := strings.TrimPrefix(t, "/")
+	body = strings.TrimPrefix(body, "!")
 	if sp := strings.IndexByte(body, ' '); sp >= 0 {
 		return strings.ToLower(body[:sp]), strings.TrimSpace(body[sp+1:])
 	}

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -42,6 +42,9 @@ func TestSplitCommand(t *testing.T) {
 		{"/model anthropic/claude", "model", "anthropic/claude"},
 		{"/think high", "think", "high"},
 		{"/COMPACT  keep the api notes ", "compact", "keep the api notes"},
+		{"!new", "new", ""},
+		{"!session", "session", ""},
+		{"!model deepseek/", "model", "deepseek/"},
 	}
 	for _, c := range cases {
 		name, arg := splitCommand(c.in)


### PR DESCRIPTION
Makes `!` a full alias for `/` on bridged commands, per Zach: `!new` ≡ `/new`, `!session` ≡ `/session`, etc.

- `handleCanonical` accepts either prefix
- `splitCommand` strips one leading `!` (after `/`)
- Unknown `!`-input still falls through to the agent as a literal prompt
- Non-owner messages remain literal text regardless of prefix
- TestSplitCommand extended; README documents the alias