### PR TITLE
fix: hold typing indicator until a reply's routing line resolves (#44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,12 @@ Multiple accounts: add more keys under `accounts`; `default` is used unless you 
 
 Set `room` on an account (a single MUC JID, or an array of them) and pi-msg
 **also** joins each. **The owner's 1:1 stays the primary channel** — joining a
-room is purely additive and doesn't change 1:1 behaviour (typing indicator,
-lifecycle notices, and unsolicited output all still go to the owner). Each reply
-goes back to whichever channel the message arrived on, including the specific
+room is purely additive and doesn't change 1:1 behaviour (lifecycle notices, and
+unsolicited output all still go to the owner). The **typing indicator** now tails
+the reply's `to:` routing line (issue #44): it points at whichever 1:1 recipient
+the reply names — the DM, another agent — and stays dark when the reply heads
+to a room or `to: noop`. Each reply goes back to wherever its routing line
+points, including the specific
 room when several are joined. Room messages are handled on **two independent
 axes**:
 

--- a/bridge.go
+++ b/bridge.go
@@ -56,7 +56,6 @@ type Bridge struct {
 	streamingRun   bool
 	repliedThisRun bool
 	shuttingDown   bool
-	directTurn     bool          // active turn arrived as a 1:1 owner DM (drives typing)
 	routingNudges  int           // mis-routed-reply corrections sent this user turn (bounded)
 	pendingNudge   *pendingNudge // staged routing correction, decided at agent_settled (#16)
 	reactTo        string        // full JID of the owner message the current run reacts to
@@ -71,8 +70,11 @@ type Bridge struct {
 	lifecycleReactTo string // snapshot of reactTo at run start, for lifecycle auto-reacts
 	lifecycleReactID string // snapshot of reactID at run start; never overwritten by deliverReply
 
-	typingMu   sync.Mutex
-	typingStop chan struct{}
+	typingMu          sync.Mutex
+	typingStop        chan struct{}
+	typingTo          string // JID currently showing "composing" ("" if none)
+	typingStream      string // accumulated streamed reply text (room-mode routing)
+	typingRoutingDone bool   // routing decision for the streaming reply already made
 
 	ambientMu sync.Mutex
 	ambient   []ambientMsg
@@ -526,7 +528,6 @@ func (b *Bridge) handleToolRelay(id, payload string) {
 // commands that need a response block only this handler, not pi's event
 // stream.
 func (b *Bridge) onInbound(m InboundMessage) {
-	b.setDirectTurn(m.Direct)
 	b.resetRoutingNudges() // fresh user turn — allow corrections again
 	// Any inbound message is activity: come back to available and restart the
 	// idle-away timer from now (a run still in flight keeps dnd — leave its
@@ -1743,9 +1744,6 @@ func routeLine(line string) (dest, inline string, ok bool) {
 // destNoopName is the reserved "discard this segment" routing destination.
 const destNoopName = "noop"
 
-func (b *Bridge) setDirectTurn(v bool) { b.mu.Lock(); b.directTurn = v; b.mu.Unlock() }
-func (b *Bridge) isDirectTurn() bool   { b.mu.Lock(); defer b.mu.Unlock(); return b.directTurn }
-
 func (b *Bridge) handleModel(arg string) {
 	if arg == "" {
 		b.reply("usage: /model <provider/id> or /model <search>")
@@ -1927,9 +1925,21 @@ func (b *Bridge) handleStreamDelta(ev Event) {
 		b.xmpp.SetPresence("dnd", "thinking…")
 	case "text_start":
 		b.xmpp.SetPresence("dnd", "replying…")
-		b.startTyping()
+		// In a room-mode account the reply's destination is only known once
+		// its "to: <jid>" routing line streams in, so typing is withheld
+		// until then rather than lit speculatively on the owner (issue #44).
+		// A pure 1:1 account has no routing — always the owner.
+		if !b.acct.RoomMode() {
+			b.startTypingTo(b.acct.Owner)
+		}
+		b.resetStreamTyping()
+	case "text_delta":
+		if b.acct.RoomMode() {
+			b.streamTypingDelta(ame.Str("delta"))
+		}
 	case "text_end":
 		b.stopTyping()
+		b.resetStreamTyping()
 	}
 }
 
@@ -1962,20 +1972,47 @@ func truncateLabel(s string, max int) string {
 }
 
 // --- typing indicator ---
+// The XEP-0085 typing indicator is a per-recipient 1:1 chat state whose job is
+// "a message is arriving right now". In a room-mode account the destination is
+// only decided by the reply's "to: <jid>" routing line, so typing is withheld
+// rather than lit speculatively on the owner: it is sent only once that routing
+// streams in, and then toward THE recipient it leads to — a reply that heads
+// to a room or to "noop" keeps the composer dark (issue #44). A pure 1:1
+// account has no routing and always points at the owner.
 
-func (b *Bridge) startTyping() {
-	// Typing is a 1:1-owner chat-state; only lit when the active turn is an owner
-	// DM (pure 1:1, or a DM while also in a room). Room turns skip it — but
-	// enabling a room no longer disables typing on the owner's 1:1.
-	if !b.isDirectTurn() {
+// resetStreamTyping clears the text stream used to re-assemble a streamed
+// reply's routing decision. Called before every text_start / text_end from the
+// event-loop goroutine (single thread), so the buffer needs no extra lock.
+func (b *Bridge) resetStreamTyping() {
+	b.typingStream = ""
+	b.typingRoutingDone = false
+}
+
+// startTypingTo lights the "composing" chat-state toward a specific recipient,
+// re-issuing it every typingRefresh so clients don't auto-clear the bubble
+// while the agent keeps working. Redirects cleanly if the streamed routing line
+// later points at a different 1:1 recipient than the one already lit.
+func (b *Bridge) startTypingTo(to string) {
+	if to == "" {
 		return
 	}
 	b.typingMu.Lock()
 	defer b.typingMu.Unlock()
-	b.xmpp.ChatState("composing")
 	if b.typingStop != nil {
-		return
+		if b.typingTo == to {
+			return // already typing toward this recipient; keep the live ticker
+		}
+		// Redirect to a different recipient: clear the old bubble first.
+		old := b.typingTo
+		close(b.typingStop)
+		b.typingStop = nil
+		b.typingTo = ""
+		if old != "" {
+			b.xmpp.ChatStateTo("active", old)
+		}
 	}
+	b.xmpp.ChatStateTo("composing", to)
+	b.typingTo = to
 	stop := make(chan struct{})
 	b.typingStop = stop
 	go func() {
@@ -1986,22 +2023,80 @@ func (b *Bridge) startTyping() {
 			case <-stop:
 				return
 			case <-tk.C:
-				b.xmpp.ChatState("composing")
+				b.xmpp.ChatStateTo("composing", to)
 			}
 		}
 	}()
 }
 
+// streamTypingDelta feeds one streamed text chunk into the room-mode typing
+// decision. Once the reply's first complete routing line is recognised it
+// lights typing toward that line's 1:1 recipient, or leaves it dark when the
+// reply heads to a room / "noop" / nowhere. After a decision the buffer is
+// frozen for the rest of the message.
+func (b *Bridge) streamTypingDelta(delta string) {
+	if delta == "" || b.typingRoutingDone {
+		return
+	}
+	b.typingStream += delta
+	target, decided := streamTypingTarget(b.typingStream, b.xmpp)
+	if !decided {
+		return
+	}
+	b.typingRoutingDone = true
+	if target == "" {
+		b.stopTyping()
+		return
+	}
+	b.startTypingTo(target)
+}
+
+// streamTypingTarget inspects the partial streamed text for a completed routing
+// line and maps it to a typing recipient. It returns (target, true) once a
+// routing line resolves — target "" means the composer must stay dark — or
+// ("", false) while the text is still streaming and no complete line exists.
+// Only a destination that classifies as a 1:1 chat (the owner or a plain
+// occupant) earns an indicator; a room, "noop", or blocked target never lights
+// the owner's bubble.
+func streamTypingTarget(buf string, xm *XMPPBridge) (target string, decided bool) {
+	hasEnd := strings.HasSuffix(buf, "\n")
+	lines := strings.Split(buf, "\n")
+	end := len(lines)
+	if !hasEnd {
+		end = len(lines) - 1 // the trailing fragment is still mid-stream
+	}
+	for i := 0; i < end; i++ {
+		l := lines[i]
+		l = strings.TrimRight(l, "\r")
+		dest, _, ok := routeLine(l)
+		if !ok {
+			continue
+		}
+		if strings.EqualFold(dest, destNoopName) {
+			return "", true
+		}
+		if xm.classifyDest(dest) == destUser {
+			return bareJid(dest), true
+		}
+		return "", true // room, blocked, or otherwise not a 1:1 chat
+	}
+	return "", false
+}
+
 // stopTyping is unconditional so a running indicator can always be cleared
 // (avoiding a stuck "composing" if the reply channel flips mid-turn). It only
-// emits the "active" chat-state if typing was actually running.
+// emits the "active" chat-state if typing was actually running, and does so
+// toward the recipient the bubble was lit on.
 func (b *Bridge) stopTyping() {
 	b.typingMu.Lock()
 	defer b.typingMu.Unlock()
 	if b.typingStop != nil {
 		close(b.typingStop)
 		b.typingStop = nil
-		b.xmpp.ChatState("active")
+	}
+	if b.typingTo != "" {
+		b.xmpp.ChatStateTo("active", b.typingTo)
+		b.typingTo = ""
 	}
 }
 

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -179,6 +179,47 @@ func TestClassifyDest(t *testing.T) {
 	}
 }
 
+// TestStreamTypingTarget pins the room-mode typing decision (issue #44): the
+// indicator is withheld while the reply is still streaming / has not yet
+// written a routing line, and once a completed "to:" line appears it points at
+// that line's 1:1 recipient — or stays dark for a room, noop, or blocked target.
+func TestStreamTypingTarget(t *testing.T) {
+	x := NewXMPPBridge(
+		ResolvedAccount{Rooms: []string{"team@muc.x"}, Owner: "zach@x"},
+		func(InboundMessage) {}, func(string, string) {},
+	)
+	x.occupants["team@muc.x"] = map[string]string{"alice": "alice@x"}
+	cases := []struct {
+		buf     string
+		target  string
+		decided bool
+	}{
+		// Not yet a complete routing line → keep waiting.
+		{"", "", false},
+		{"to:", "", false},
+		{"to: zach", "", false},
+		{"to: zach@x", "", false},
+		// Owner 1:1 → indicator on the owner.
+		{"to: zach@x\n", "zach@x", true},
+		{"to: zach@x/phone\n", "zach@x", true},
+		// Known occupant → indicator on the occupant.
+		{"to: alice@x\n", "alice@x", true},
+		// A leading non-routing line is skipped; the routing still resolves.
+		{"sure\nto: zach@x\n", "zach@x", true},
+		// Room, noop, and unknown targets never light the owner's bubble.
+		{"to: team@muc.x\n", "", true},
+		{"to: noop\n", "", true},
+		{"to: stranger@x\n", "", true},
+	}
+	for _, c := range cases {
+		got, decided := streamTypingTarget(c.buf, x)
+		if got != c.target || decided != c.decided {
+			t.Errorf("streamTypingTarget(%q) = (%q,%v), want (%q,%v)",
+				c.buf, got, decided, c.target, c.decided)
+		}
+	}
+}
+
 // TestErrorRoomInvisibleToAgent verifies the write-only error room is NOT in
 // roomBares (so dispatch ignores it) and is NOT an allowed reply/send
 // destination — agents can't read it or route to it.
@@ -392,7 +433,7 @@ func TestIdleAwayClock(t *testing.T) {
 // clock so a quiet stretch still produces an away transition.
 func TestInboundRearmsIdleClock(t *testing.T) {
 	b := roomBridge()
-	b.idleSince = time.Time{}          // e.g. just cleared by a prior markActive
+	b.idleSince = time.Time{} // e.g. just cleared by a prior markActive
 	b.awayAnnounced = false
 
 	// Ambient room message: not from the owner, not addressed to the bot →
@@ -412,7 +453,6 @@ func TestInboundRearmsIdleClock(t *testing.T) {
 		t.Error("onInbound should leave awayAnnounced false so a fresh away can be announced")
 	}
 }
-
 
 // TestIdleTickNoSelfDeadlockWhileStreaming guards against a regression where
 // idleTick held b.mu and then called streaming() (which itself locks b.mu),

--- a/xmpp.go
+++ b/xmpp.go
@@ -1277,10 +1277,18 @@ func (b *XMPPBridge) GoOffline(status string) {
 // ChatState sends an XEP-0085 chat-state notification to the owner (the
 // "typing…" indicator). "composing" shows typing; "active" clears it.
 func (b *XMPPBridge) ChatState(state string) {
+	b.ChatStateTo(state, b.acct.Owner)
+}
+
+// ChatStateTo sends an XEP-0085 chat-state notification to a specific JID. The
+// typing indicator is a per-recipient 1:1 chat state, so a reply routed to (or
+// from) someone other than the owner points the bubble at that recipient rather
+// than always lighting the owner (issue #44).
+func (b *XMPPBridge) ChatStateTo(state, to string) {
 	if b.currentSession() == nil {
 		return
 	}
-	if err := b.encodeChatState(b.acct.Owner, state, stanza.ChatMessage); err != nil {
+	if err := b.encodeChatState(to, state, stanza.ChatMessage); err != nil {
 		b.log("warning", "chatstate failed: "+err.Error())
 	}
 }


### PR DESCRIPTION
Closes #44

## Problem
In room-mode the XEP-0085 typing indicator was lit on the owner the instant an assistant message began streaming (`text_start`), even when the reply was routed to a room, sent to another agent, or was `to: noop`. The owner saw a false typing bubble on replies that never reached him.

## Fix
Decide the bubble from where the reply's own `to: <jid>` routing line points, as it streams in:

- **owner or known occupant → light that recipient's bubble** (not always the owner)
- **room / `to: noop` / blocked / no routing line → composer stays dark**

Typing is now a per-recipient chat state (`ChatStateTo`), replacing the old `directTurn` heuristic with a routing-accurate decision. A pure 1:1 account (no room) is unchanged — always the owner.

## Tests
- `go vet ./...` and `go test` pass.
- New `TestStreamTypingTarget` covers owner / occupant / room / noop / blocked and mid-stream (unfinished) routing lines.

No artifact — this is a long-running daemon (the pi-msg XMPP bridge), not a web app, so the PR is the deliverable. Not deployed (fleet/production infra is out of scope for r2d2).