### PR TITLE
bridge: send one read receipt per 1:1 message (drop XEP-0184, keep XEP-0333 displayed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,8 @@ sequenceDiagram
   when idle), and a presence **status** label of the current activity (`thinking…`,
   `running: <cmd>`, `replying…`, `retrying…`, `listening`). When a run settles with
   **no** text you get a `✅ done (no reply) — your turn` nudge.
-- Messages you send are acknowledged with **read receipts** — XEP-0184 delivery
-  receipts and XEP-0333 chat markers (`displayed`) — when the agent takes them in, if
-  your client requests them.
+- Messages you send are acknowledged with a single **read receipt** — a XEP-0333
+  chat marker (`displayed`) — when the agent takes them in, if your client requests it.
 - Your chat messages → routed to Pi:
 
 | You send | Becomes |

--- a/xmpp.go
+++ b/xmpp.go
@@ -1350,19 +1350,16 @@ func (b *XMPPBridge) encodeChatState(to, state string, typ stanza.MessageType) e
 	return b.encode(ctx, session, msg)
 }
 
-// sendReceipts acknowledges an accepted 1:1 owner message: a XEP-0184 delivery
-// receipt if the sender requested one, and a XEP-0333 "displayed" chat marker
-// if the message was markable — a genuine read receipt, since the agent is
-// about to act on it. Sent to the message's full from-JID so it routes back to
-// the originating resource. Best-effort; failures are logged, not fatal.
+// sendReceipts acknowledges an accepted 1:1 owner message with a single
+// XEP-0333 "displayed" chat marker if the message was markable — a genuine
+// read receipt, since the agent is about to act on it. Sent to the message's
+// full from-JID so it routes back to the originating resource. Only one ack is
+// sent per message (a lone XEP-0333 marker, not both a delivery receipt AND a
+// marker), so chat clients don't show a doubled acknowledgment. Best-effort;
+// failures are logged, not fatal.
 func (b *XMPPBridge) sendReceipts(m incomingMsg) {
 	if m.id == "" || m.from == "" {
 		return
-	}
-	if m.wantReceipt {
-		if err := b.encodeReceipt(m.from, receiptsNS, "received", m.id); err != nil {
-			b.log("warning", "delivery receipt failed: "+err.Error())
-		}
 	}
 	if m.markable {
 		if err := b.encodeReceipt(m.from, chatMarkersNS, "displayed", m.id); err != nil {


### PR DESCRIPTION
Fixes the doubled ack the owner saw on `/new` over 1:1 (beltino user).

**Root cause:** `sendReceipts` (`xmpp.go:1358`) sent **both** a XEP-0184 `<received/>` receipt and a XEP-0333 `<displayed/>` marker for every accepted 1:1 owner message. Clients that request both render those as two separate ack ticks on each message. Only beltino showed it — it's the one account driven over 1:1 DM (room messages never get receipts, so the personas didn't).

**Change:** `sendReceipts` now sends a single XEP-0333 `displayed` chat marker (a genuine read receipt) and drops the XEP-0184 receipt. README updated to match.

Build, vet, tests green; no test changes needed (`TestReceiptAckMarshal` validates the shared wire form, which is unchanged).