### PR TITLE
feat: XEP-0359 reply-stamp on 1:1 replies with queued follow-ups

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -71,6 +71,14 @@ type Bridge struct {
 	lifecycleReactTo string // snapshot of reactTo at run start, for lifecycle auto-reacts
 	lifecycleReactID string // snapshot of reactID at run start; never overwritten by deliverReply
 
+	// pending1to1 is the FIFO of owner 1:1 stanza IDs received but not yet
+	// processed into a run. It answers "are there more messages behind this
+	// reply?" (XEP-0359 reply stamping): a reply only carries <reply> to the
+	// last processed message when this queue is still non-empty at deliver time
+	// — i.e. the owner sent more than that reply resolves.
+	pending1to1 []string
+	lastReplyTo string // stanza ID of the most recently processed 1:1 message
+
 	typingMu          sync.Mutex
 	typingStop        chan struct{}
 	typingTo          string // JID currently showing "composing" ("" if none)
@@ -351,6 +359,14 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		b.setHandleWarned(false)
 		b.clearPendingNudge() // a new run starts — discard any stale staged correction (#16)
 		b.reactionAckRun = false
+		// This run is processing the oldest unanswered 1:1 message — promote it
+		// so replies stamp against the last processed message (XEP-0359).
+		b.mu.Lock()
+		if len(b.pending1to1) > 0 {
+			b.lastReplyTo = b.pending1to1[0]
+			b.pending1to1 = b.pending1to1[1:]
+		}
+		b.mu.Unlock()
 		b.markActive() // a run is in flight — not idle
 		b.xmpp.SetPresence("dnd", "thinking…")
 		b.lifecycleReact("👀") // picked up (opt-in via the reactions flag)
@@ -682,6 +698,15 @@ func (b *Bridge) handleCanonical(text, origin, sender, reactTo, reactID string) 
 	// and remember where a reply (or tool-driven file) should go by default.
 	b.setLifecycleReactTarget(reactTo, reactID)
 	b.setTurnDest(origin)
+	// Owner 1:1 (origin is the owner, no room): stage this message as an
+	// unanswered inbound for XEP-0359 reply stamping. It sits in pending1to1
+	// until agent_start promotes it to lastReplyTo. Control commands return
+	// above, so they never enter this queue.
+	if origin == b.acct.Owner && reactID != "" {
+		b.mu.Lock()
+		b.pending1to1 = append(b.pending1to1, reactID)
+		b.mu.Unlock()
+	}
 	b.rpc.Prompt(b.composePrompt(t, true, "", origin, sender, reactID, reactTo), b.steerBehavior())
 	b.busyPresence("thinking…")
 }
@@ -1558,7 +1583,16 @@ func (b *Bridge) deliverReply(text string) {
 		// Deliberate reactions are the send_reaction tool's job now; a 1:1 reply
 		// is just its text.
 		if strings.TrimSpace(text) != "" {
-			stanzaID := b.xmpp.Send(text)
+			// If unanswered owner messages are still queued behind this reply, stamp
+			// it with a XEP-0359 <reply> to the last processed one (which message
+			// this answers when several arrived at once). Keep the common
+			// single-message turn unstamped so every reply isn't a threaded bubble.
+			var stanzaID string
+			if rt := b.replyToStamp(); rt != "" {
+				stanzaID = b.xmpp.SendChatToReplyTo(text, rt)
+			} else {
+				stanzaID = b.xmpp.Send(text)
+			}
 			// Update reaction target to the just-sent message so subsequent
 			// send_reaction calls target the agent's own message.
 			if stanzaID != "" {
@@ -2225,6 +2259,20 @@ func (b *Bridge) stopTyping() {
 	}
 }
 
+// replyToStamp returns the XEP-0359 target for the current 1:1 reply (the
+// stanza ID of the last processed owner message), but only when unanswered 1:1
+// messages are still queued behind it. Returns "" — no stamp — otherwise, so a
+// reply that resolves the whole backlog (or an idle single-message turn) stays
+// flat.
+func (b *Bridge) replyToStamp() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if len(b.pending1to1) == 0 {
+		return ""
+	}
+	return b.lastReplyTo
+}
+
 // settleLocally resets run-scoped UI (streaming flag, typing indicator,
 // presence) when a control command ends the current run directly. Pi answers
 // `abort` with an `error`(aborted) event rather than `agent_settled`, so the
@@ -2238,6 +2286,12 @@ func (b *Bridge) settleLocally() {
 	b.markIdle()
 	b.xmpp.SetPresence("", "listening")
 	b.clearPendingNudge() // aborted run — discard any staged correction (#16)
+	// Aborted/new run: drop the unanswered-1:1 bookkeeping so a stale lastReplyTo
+	// can't leak a reply-stamp onto a later, unrelated turn.
+	b.mu.Lock()
+	b.pending1to1 = nil
+	b.lastReplyTo = ""
+	b.mu.Unlock()
 }
 
 // idleAwayTimeout is how long the agent may sit idle before its presence

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -584,6 +584,61 @@ func TestToolRelaySuccessOk(t *testing.T) {
 	}
 }
 
+// TestReplyToStamp covers the XEP-0359 reply-stamp decision for owner messages.
+// A reply is only stamped (to the last *processed* message) when unanswered 1:1
+// messages are still queued behind it — the "sent several before any reply"
+// case. Single-message turns and a drained backlog stay unstamped.
+func TestReplyToStamp(t *testing.T) {
+	b := NewBridge(ResolvedAccount{Owner: "zach@x.com"}, false)
+	b.rpc = &RPCClient{}   // fire-and-forget prompt to nowhere
+	b.xmpp = &XMPPBridge{} // busyPresence/agent_start call SetPresence
+
+	stamp := func() string { return b.replyToStamp() }
+
+	// A arrives; nothing processed yet → no stamp.
+	b.handleCanonical("msg A", b.acct.Owner, "", "zach@x.com/res", "id-A")
+	if got := stamp(); got != "" {
+		t.Fatalf("before any agent_start, stamp = %q, want \"\"", got)
+	}
+
+	// A is promoted to a run (agent_start pops it). No backlog → no stamp.
+	b.handleRPCEvent(Event{"type": "agent_start"})
+	if got := stamp(); got != "" {
+		t.Fatalf("single processed message, stamp = %q, want \"\"", got)
+	}
+
+	// B arrives while A is being processed → it sits queued, unanswered.
+	b.handleCanonical("msg B", b.acct.Owner, "", "zach@x.com/res", "id-B")
+	// A's reply resolves only A; B still queued → stamp to the last processed (A).
+	if got := stamp(); got != "id-A" {
+		t.Fatalf("A's reply with B queued, stamp = %q, want id-A", got)
+	}
+
+	// B is processed next → both handled, backlog drained → no stamp.
+	b.handleRPCEvent(Event{"type": "agent_start"})
+	if got := stamp(); got != "" {
+		t.Fatalf("backlog drained, stamp = %q, want \"\"", got)
+	}
+}
+
+// TestReplyToStampClearedOnReset: settleLocally (abort/new) wipes the 1:1
+// bookkeeping so a stale stamp can't leak onto a later, unrelated turn.
+func TestReplyToStampClearedOnReset(t *testing.T) {
+	b := NewBridge(ResolvedAccount{Owner: "zach@x.com"}, false)
+	b.rpc = &RPCClient{}
+	b.xmpp = &XMPPBridge{} // settleLocally calls SetPresence — non-nil avoids a panic
+	b.handleCanonical("msg A", b.acct.Owner, "", "zach@x.com/res", "id-A")
+	b.handleRPCEvent(Event{"type": "agent_start"})
+	b.handleCanonical("msg B", b.acct.Owner, "", "zach@x.com/res", "id-B")
+	if got := b.replyToStamp(); got != "id-A" {
+		t.Fatalf("pre-reset stamp = %q, want id-A", got)
+	}
+	b.settleLocally()
+	if got := b.replyToStamp(); got != "" {
+		t.Fatalf("post-reset stamp = %q, want \"\"", got)
+	}
+}
+
 // nopClose adapts a bytes.Buffer to io.WriteCloser for RPCClient.stdin.
 type nopClose struct{ buf *bytes.Buffer }
 

--- a/xmpp.go
+++ b/xmpp.go
@@ -1148,13 +1148,29 @@ func (b *XMPPBridge) Send(text string) string { return b.SendChatTo(b.acct.Owner
 // SendChatTo posts a 1:1 chat message to an arbitrary JID, splitting long text.
 // Returns the stanza ID of the last chunk sent, or "" if nothing was sent.
 func (b *XMPPBridge) SendChatTo(to, text string) string {
+	return b.sendChat(to, text, "")
+}
+
+// SendChatToReplyTo posts a 1:1 chat message carrying a XEP-0359 <reply>
+// element referencing the stanza ID of the owner message it answers (""
+// disables the stamp). Used to thread replies to one of several messages sent
+// before any reply.
+func (b *XMPPBridge) SendChatToReplyTo(text, replyTo string) string {
+	return b.sendChat(b.acct.Owner, text, replyTo)
+}
+
+func (b *XMPPBridge) sendChat(to, text, replyTo string) string {
 	if b.currentSession() == nil {
 		b.log("warning", "send skipped: not online")
 		return ""
 	}
 	var lastID string
-	for _, part := range chunk(text, maxBody) {
-		id, err := b.encodeChat(to, part, stanza.ChatMessage)
+	for i, part := range chunk(text, maxBody) {
+		rt := replyTo
+		if i > 0 {
+			rt = "" // only the first chunk of a split reply carries the thread stamp
+		}
+		id, err := b.encodeChat(to, part, stanza.ChatMessage, rt)
 		if err != nil {
 			b.log("error", "send failed: "+err.Error())
 			break
@@ -1304,7 +1320,7 @@ func (b *XMPPBridge) currentSession() *xmpp.Session {
 
 // --- stanza encoders ---
 
-func (b *XMPPBridge) encodeChat(to, body string, typ stanza.MessageType) (string, error) {
+func (b *XMPPBridge) encodeChat(to, body string, typ stanza.MessageType, replyTo string) (string, error) {
 	session := b.currentSession()
 	if session == nil {
 		return "", fmt.Errorf("not online")
@@ -1316,15 +1332,26 @@ func (b *XMPPBridge) encodeChat(to, body string, typ stanza.MessageType) (string
 	id := newStanzaID()
 	msg := struct {
 		stanza.Message
-		Body string `xml:"body"`
+		Body  string     `xml:"body"`
+		Reply *replyElem `xml:",omitempty"`
 	}{
 		Message: stanza.Message{ID: id, To: toJID, Type: typ},
 		Body:    body,
+	}
+	if replyTo != "" {
+		msg.Reply = &replyElem{To: replyTo}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	b.recordMessage(id, to)
 	return id, b.encode(ctx, session, msg)
+}
+
+// replyElem is the XEP-0359 stanza-identification reply element: minimal form
+// of "this message is a reply to message <to>".
+type replyElem struct {
+	XMLName xml.Name `xml:"urn:xmpp:reply:0 reply"`
+	To      string   `xml:"to,attr"`
 }
 
 func (b *XMPPBridge) encodeChatState(to, state string, typ stanza.MessageType) error {
@@ -1723,7 +1750,7 @@ func (b *XMPPBridge) SendRoomTo(room, text string) string {
 	}
 	var lastID string
 	for _, part := range chunk(text, maxBody) {
-		id, err := b.encodeChat(room, part, stanza.GroupChatMessage)
+		id, err := b.encodeChat(room, part, stanza.GroupChatMessage, "")
 		if err != nil {
 			b.log("error", "room send failed: "+err.Error())
 			break

--- a/xmpp_test.go
+++ b/xmpp_test.go
@@ -123,6 +123,29 @@ func TestReceiptAckMarshal(t *testing.T) {
 	}
 }
 
+// replyEl / replyPayload mirror the wire struct built by encodeChat when a
+// XEP-0359 reply target is set, so the threaded-reply form can be asserted
+// without a live session.
+func replyPayload(forID string) any {
+	return struct {
+		XMLName xml.Name
+		To      string `xml:"to,attr"`
+	}{XMLName: xml.Name{Space: "urn:xmpp:reply:0", Local: "reply"}, To: forID}
+}
+
+func TestReplyMarshal(t *testing.T) {
+	out, err := xml.Marshal(replyPayload("msg-42"))
+	if err != nil {
+		t.Fatalf("marshal reply: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{"<reply", `xmlns="urn:xmpp:reply:0"`, `to="msg-42"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("reply payload = %q, missing %q", got, want)
+		}
+	}
+}
+
 // reactionEl / reactionsPayload mirror the wire struct built by encodeReaction,
 // so the XEP-0444 form can be asserted without a live session.
 type reactionEl struct {


### PR DESCRIPTION
A 1:1 reply now carries a XEP-0359 `<reply to='...'>` element pointing at the **last owner message the bridge processed** — but **only when unanswered 1:1 messages are still queued behind it**.

## Why
When several messages arrive before any reply (e.g. "A … second sentence B"), it wasn't clear which reply serves which message. This threads a reply to the message it answers.

```
A arrives          → agent_start promotes A → pending=[A] → []
B arrives (queued) → pending=[B]
A's reply          → pending non-empty → <reply to='idA'>
B processed        → agent_start pops B → pending=[]
B's reply          → pending empty → no stamp
```

## Scope / guarantees
- **1:1 only** — room mode untouched.
- **Control commands** (`/new` etc.) never enter the queue.
- **Split long replies**: only the first chunk carries the stamp.
- **settleLocally** (abort/new) clears the bookkeeping so a stale stamp can't leak onto a later turn.
- Common single-message turns stay **unstamped** (no threaded bubble on every reply).

## Wire form
Minimal XEP-0359 reply element: `<reply to='{id}' xmlns='urn:xmpp:reply:0'/>`.

Build, vet, and the full test suite pass. New tests cover the stamp decision (single-message / queued-backlog / drained) and the XEP-0359 marshalling.

**One runtime assumption to verify live:** the design keys off `agent_start` firing once per *processed* owner message (a queued steer after the previous run settles promotes B). If pi ever reads a steer *into* the streaming run instead, that run's reply would stamp to the earlier message — the stamped target is still correct for the observed deferred behavior. Flagging rather than hiding it.