### PR TITLE
fix: reply-stamp for owner 1:1 segments in room-mode accounts

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -1589,7 +1589,7 @@ func (b *Bridge) deliverReply(text string) {
 			// single-message turn unstamped so every reply isn't a threaded bubble.
 			var stanzaID string
 			if rt := b.replyToStamp(); rt != "" {
-				stanzaID = b.xmpp.SendChatToReplyTo(text, rt)
+				stanzaID = b.xmpp.SendChatToReplyTo(b.acct.Owner, text, rt)
 			} else {
 				stanzaID = b.xmpp.Send(text)
 			}
@@ -1638,6 +1638,17 @@ func (b *Bridge) deliverReply(text string) {
 				// nobody and reports nothing, so the sender believes the
 				// handoff landed.
 				b.warnHandleProblems(bareJid(s.dest), s.body)
+			} else if bareJid(s.dest) == b.acct.Owner {
+				// Owner 1:1 segment (room-mode reply routed to the owner's
+				// personal chat): same XEP-0359 stamping decision as the pure
+				// 1:1 branch — stamp when unanswered owner messages are still
+				// queued behind this reply. Never stamp reaches to other JIDs;
+				// the pending1to1 queue only ever holds owner messages.
+				if rt := b.replyToStamp(); rt != "" {
+					stanzaID = b.xmpp.SendChatToReplyTo(s.dest, s.body, rt)
+				} else {
+					stanzaID = b.xmpp.SendChatTo(s.dest, s.body)
+				}
 			} else {
 				stanzaID = b.xmpp.SendChatTo(s.dest, s.body)
 			}

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -639,6 +639,51 @@ func TestReplyToStampClearedOnReset(t *testing.T) {
 	}
 }
 
+// TestReplyToStampRoomMode: the live beltino account is room-mode (it has a
+// room configured), so owner replies are routed as "to: <jid>" segments. A
+// segment addressed to the owner must get the same XEP-0359 stamp decision as
+// a pure-1:1 reply — and a room segment must never be stamped with an
+// owner-message id.
+func TestReplyToStampRoomMode(t *testing.T) {
+	b := roomBridge() // rooms + owner zach@x.com
+	b.rpc = &RPCClient{}
+	b.xmpp = &XMPPBridge{ownerBare: "zach@x.com", roomBares: map[string]bool{"team@muc.x.com": true}}
+
+	// Owner sends two messages; the run for A is in flight (agent_start popped
+	// A), B is queued behind it.
+	b.handleCanonical("msg A", b.acct.Owner, "", "zach@x.com/res", "id-A")
+	b.handleRPCEvent(Event{"type": "agent_start"})
+	b.handleCanonical("msg B", b.acct.Owner, "", "zach@x.com/res", "id-B")
+
+	// The reply to A carries an owner 1:1 segment (stamps) and a room segment.
+	// The room segment routes via SendRoomTo (no XEP-0359 plumbing at all), so
+	// only the owner chat send is observable through onSendChat — that's the
+	// point: rooms can never carry an owner stamp.
+	ownerSends := 0
+	b.xmpp.onSendChat = func(to, text, replyTo string) {
+		ownerSends++
+		if bareJid(to) != b.acct.Owner {
+			t.Errorf("onSendChat fired for non-owner %q — rooms must use SendRoomTo", to)
+		}
+		if replyTo != "id-A" {
+			t.Errorf("owner segment: replyTo = %q, want id-A", replyTo)
+		}
+	}
+	b.deliverReply("to: zach@x.com\nfor A\nto: team@muc.x.com\nroom note")
+	if ownerSends != 1 {
+		t.Errorf("deliverReply made %d owner chat sends, want 1", ownerSends)
+	}
+
+	// B's run drains the backlog — its owner segment must not stamp.
+	b.handleRPCEvent(Event{"type": "agent_start"})
+	b.xmpp.onSendChat = func(to, text, replyTo string) {
+		if bareJid(to) == b.acct.Owner && replyTo != "" {
+			t.Errorf("drained run: owner replyTo = %q, want \"\"", replyTo)
+		}
+	}
+	b.deliverReply("to: zach@x.com\nfor B")
+}
+
 // nopClose adapts a bytes.Buffer to io.WriteCloser for RPCClient.stdin.
 type nopClose struct{ buf *bytes.Buffer }
 

--- a/xmpp.go
+++ b/xmpp.go
@@ -292,6 +292,12 @@ type XMPPBridge struct {
 	onMsg     func(InboundMessage)
 	logf      func(level, msg string)
 
+	// onSendChat records a chat-send routing decision (test hook): called once
+	// per sendChat with the destination, last chunk, and the XEP-0359 reply
+	// target. Fires before the online check so route selection (stamped vs
+	// plain) is observable without a live session.
+	onSendChat func(to, text, replyTo string)
+
 	mu       sync.Mutex
 	session  *xmpp.Session
 	online   bool
@@ -1155,11 +1161,14 @@ func (b *XMPPBridge) SendChatTo(to, text string) string {
 // element referencing the stanza ID of the owner message it answers (""
 // disables the stamp). Used to thread replies to one of several messages sent
 // before any reply.
-func (b *XMPPBridge) SendChatToReplyTo(text, replyTo string) string {
-	return b.sendChat(b.acct.Owner, text, replyTo)
+func (b *XMPPBridge) SendChatToReplyTo(to, text, replyTo string) string {
+	return b.sendChat(to, text, replyTo)
 }
 
 func (b *XMPPBridge) sendChat(to, text, replyTo string) string {
+	if b.onSendChat != nil {
+		b.onSendChat(to, text, replyTo)
+	}
 	if b.currentSession() == nil {
 		b.log("warning", "send skipped: not online")
 		return ""


### PR DESCRIPTION
The XEP-0359 reply-stamp shipped in #50 only covered **pure-1:1 accounts** (`!RoomMode()`). The live beltino account is room-mode — it has a room + error room configured — so every reply, including owner 1:1 chat, routes through the `to: <jid>` segment loop. The stamp branch never executed in production.

**Fix:** an owner-destined segment now gets the same `replyToStamp` decision as the pure-1:1 branch (stamp when unanswered owner messages are still queued). Rooms are untouched — they route via `SendRoomTo`, which has no stamp plumbing at all, so a stamp can never leak into a room.

- `SendChatToReplyTo` gains a `to` param (shared by both branches)
- `onSendChat` test hook records routing decisions without a live session
- Tests: owner segment stamps with a queued message; drained runs stay flat; rooms never hit the stamped sender

Verified against live timestamps: the backlog DID form during testing (three messages inside ~20s) but every reply either went out unstamped through the room path or was dropped for a missing `to:` line (my slip, unrelated). This closes the gap for the real account.
