### PR TITLE
revert: drop XEP-0359 reply-stamp (PR #50 + #51)

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -1589,7 +1589,7 @@ func (b *Bridge) deliverReply(text string) {
 			// single-message turn unstamped so every reply isn't a threaded bubble.
 			var stanzaID string
 			if rt := b.replyToStamp(); rt != "" {
-				stanzaID = b.xmpp.SendChatToReplyTo(b.acct.Owner, text, rt)
+				stanzaID = b.xmpp.SendChatToReplyTo(text, rt)
 			} else {
 				stanzaID = b.xmpp.Send(text)
 			}
@@ -1638,17 +1638,6 @@ func (b *Bridge) deliverReply(text string) {
 				// nobody and reports nothing, so the sender believes the
 				// handoff landed.
 				b.warnHandleProblems(bareJid(s.dest), s.body)
-			} else if bareJid(s.dest) == b.acct.Owner {
-				// Owner 1:1 segment (room-mode reply routed to the owner's
-				// personal chat): same XEP-0359 stamping decision as the pure
-				// 1:1 branch — stamp when unanswered owner messages are still
-				// queued behind this reply. Never stamp reaches to other JIDs;
-				// the pending1to1 queue only ever holds owner messages.
-				if rt := b.replyToStamp(); rt != "" {
-					stanzaID = b.xmpp.SendChatToReplyTo(s.dest, s.body, rt)
-				} else {
-					stanzaID = b.xmpp.SendChatTo(s.dest, s.body)
-				}
 			} else {
 				stanzaID = b.xmpp.SendChatTo(s.dest, s.body)
 			}

--- a/bridge.go
+++ b/bridge.go
@@ -71,14 +71,6 @@ type Bridge struct {
 	lifecycleReactTo string // snapshot of reactTo at run start, for lifecycle auto-reacts
 	lifecycleReactID string // snapshot of reactID at run start; never overwritten by deliverReply
 
-	// pending1to1 is the FIFO of owner 1:1 stanza IDs received but not yet
-	// processed into a run. It answers "are there more messages behind this
-	// reply?" (XEP-0359 reply stamping): a reply only carries <reply> to the
-	// last processed message when this queue is still non-empty at deliver time
-	// — i.e. the owner sent more than that reply resolves.
-	pending1to1 []string
-	lastReplyTo string // stanza ID of the most recently processed 1:1 message
-
 	typingMu          sync.Mutex
 	typingStop        chan struct{}
 	typingTo          string // JID currently showing "composing" ("" if none)
@@ -359,14 +351,6 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		b.setHandleWarned(false)
 		b.clearPendingNudge() // a new run starts — discard any stale staged correction (#16)
 		b.reactionAckRun = false
-		// This run is processing the oldest unanswered 1:1 message — promote it
-		// so replies stamp against the last processed message (XEP-0359).
-		b.mu.Lock()
-		if len(b.pending1to1) > 0 {
-			b.lastReplyTo = b.pending1to1[0]
-			b.pending1to1 = b.pending1to1[1:]
-		}
-		b.mu.Unlock()
 		b.markActive() // a run is in flight — not idle
 		b.xmpp.SetPresence("dnd", "thinking…")
 		b.lifecycleReact("👀") // picked up (opt-in via the reactions flag)
@@ -698,15 +682,6 @@ func (b *Bridge) handleCanonical(text, origin, sender, reactTo, reactID string) 
 	// and remember where a reply (or tool-driven file) should go by default.
 	b.setLifecycleReactTarget(reactTo, reactID)
 	b.setTurnDest(origin)
-	// Owner 1:1 (origin is the owner, no room): stage this message as an
-	// unanswered inbound for XEP-0359 reply stamping. It sits in pending1to1
-	// until agent_start promotes it to lastReplyTo. Control commands return
-	// above, so they never enter this queue.
-	if origin == b.acct.Owner && reactID != "" {
-		b.mu.Lock()
-		b.pending1to1 = append(b.pending1to1, reactID)
-		b.mu.Unlock()
-	}
 	b.rpc.Prompt(b.composePrompt(t, true, "", origin, sender, reactID, reactTo), b.steerBehavior())
 	b.busyPresence("thinking…")
 }
@@ -1583,16 +1558,7 @@ func (b *Bridge) deliverReply(text string) {
 		// Deliberate reactions are the send_reaction tool's job now; a 1:1 reply
 		// is just its text.
 		if strings.TrimSpace(text) != "" {
-			// If unanswered owner messages are still queued behind this reply, stamp
-			// it with a XEP-0359 <reply> to the last processed one (which message
-			// this answers when several arrived at once). Keep the common
-			// single-message turn unstamped so every reply isn't a threaded bubble.
-			var stanzaID string
-			if rt := b.replyToStamp(); rt != "" {
-				stanzaID = b.xmpp.SendChatToReplyTo(text, rt)
-			} else {
-				stanzaID = b.xmpp.Send(text)
-			}
+			stanzaID := b.xmpp.Send(text)
 			// Update reaction target to the just-sent message so subsequent
 			// send_reaction calls target the agent's own message.
 			if stanzaID != "" {
@@ -2259,20 +2225,6 @@ func (b *Bridge) stopTyping() {
 	}
 }
 
-// replyToStamp returns the XEP-0359 target for the current 1:1 reply (the
-// stanza ID of the last processed owner message), but only when unanswered 1:1
-// messages are still queued behind it. Returns "" — no stamp — otherwise, so a
-// reply that resolves the whole backlog (or an idle single-message turn) stays
-// flat.
-func (b *Bridge) replyToStamp() string {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-	if len(b.pending1to1) == 0 {
-		return ""
-	}
-	return b.lastReplyTo
-}
-
 // settleLocally resets run-scoped UI (streaming flag, typing indicator,
 // presence) when a control command ends the current run directly. Pi answers
 // `abort` with an `error`(aborted) event rather than `agent_settled`, so the
@@ -2286,12 +2238,6 @@ func (b *Bridge) settleLocally() {
 	b.markIdle()
 	b.xmpp.SetPresence("", "listening")
 	b.clearPendingNudge() // aborted run — discard any staged correction (#16)
-	// Aborted/new run: drop the unanswered-1:1 bookkeeping so a stale lastReplyTo
-	// can't leak a reply-stamp onto a later, unrelated turn.
-	b.mu.Lock()
-	b.pending1to1 = nil
-	b.lastReplyTo = ""
-	b.mu.Unlock()
 }
 
 // idleAwayTimeout is how long the agent may sit idle before its presence

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -584,61 +584,6 @@ func TestToolRelaySuccessOk(t *testing.T) {
 	}
 }
 
-// TestReplyToStamp covers the XEP-0359 reply-stamp decision for owner messages.
-// A reply is only stamped (to the last *processed* message) when unanswered 1:1
-// messages are still queued behind it — the "sent several before any reply"
-// case. Single-message turns and a drained backlog stay unstamped.
-func TestReplyToStamp(t *testing.T) {
-	b := NewBridge(ResolvedAccount{Owner: "zach@x.com"}, false)
-	b.rpc = &RPCClient{}   // fire-and-forget prompt to nowhere
-	b.xmpp = &XMPPBridge{} // busyPresence/agent_start call SetPresence
-
-	stamp := func() string { return b.replyToStamp() }
-
-	// A arrives; nothing processed yet → no stamp.
-	b.handleCanonical("msg A", b.acct.Owner, "", "zach@x.com/res", "id-A")
-	if got := stamp(); got != "" {
-		t.Fatalf("before any agent_start, stamp = %q, want \"\"", got)
-	}
-
-	// A is promoted to a run (agent_start pops it). No backlog → no stamp.
-	b.handleRPCEvent(Event{"type": "agent_start"})
-	if got := stamp(); got != "" {
-		t.Fatalf("single processed message, stamp = %q, want \"\"", got)
-	}
-
-	// B arrives while A is being processed → it sits queued, unanswered.
-	b.handleCanonical("msg B", b.acct.Owner, "", "zach@x.com/res", "id-B")
-	// A's reply resolves only A; B still queued → stamp to the last processed (A).
-	if got := stamp(); got != "id-A" {
-		t.Fatalf("A's reply with B queued, stamp = %q, want id-A", got)
-	}
-
-	// B is processed next → both handled, backlog drained → no stamp.
-	b.handleRPCEvent(Event{"type": "agent_start"})
-	if got := stamp(); got != "" {
-		t.Fatalf("backlog drained, stamp = %q, want \"\"", got)
-	}
-}
-
-// TestReplyToStampClearedOnReset: settleLocally (abort/new) wipes the 1:1
-// bookkeeping so a stale stamp can't leak onto a later, unrelated turn.
-func TestReplyToStampClearedOnReset(t *testing.T) {
-	b := NewBridge(ResolvedAccount{Owner: "zach@x.com"}, false)
-	b.rpc = &RPCClient{}
-	b.xmpp = &XMPPBridge{} // settleLocally calls SetPresence — non-nil avoids a panic
-	b.handleCanonical("msg A", b.acct.Owner, "", "zach@x.com/res", "id-A")
-	b.handleRPCEvent(Event{"type": "agent_start"})
-	b.handleCanonical("msg B", b.acct.Owner, "", "zach@x.com/res", "id-B")
-	if got := b.replyToStamp(); got != "id-A" {
-		t.Fatalf("pre-reset stamp = %q, want id-A", got)
-	}
-	b.settleLocally()
-	if got := b.replyToStamp(); got != "" {
-		t.Fatalf("post-reset stamp = %q, want \"\"", got)
-	}
-}
-
 // nopClose adapts a bytes.Buffer to io.WriteCloser for RPCClient.stdin.
 type nopClose struct{ buf *bytes.Buffer }
 

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -639,51 +639,6 @@ func TestReplyToStampClearedOnReset(t *testing.T) {
 	}
 }
 
-// TestReplyToStampRoomMode: the live beltino account is room-mode (it has a
-// room configured), so owner replies are routed as "to: <jid>" segments. A
-// segment addressed to the owner must get the same XEP-0359 stamp decision as
-// a pure-1:1 reply — and a room segment must never be stamped with an
-// owner-message id.
-func TestReplyToStampRoomMode(t *testing.T) {
-	b := roomBridge() // rooms + owner zach@x.com
-	b.rpc = &RPCClient{}
-	b.xmpp = &XMPPBridge{ownerBare: "zach@x.com", roomBares: map[string]bool{"team@muc.x.com": true}}
-
-	// Owner sends two messages; the run for A is in flight (agent_start popped
-	// A), B is queued behind it.
-	b.handleCanonical("msg A", b.acct.Owner, "", "zach@x.com/res", "id-A")
-	b.handleRPCEvent(Event{"type": "agent_start"})
-	b.handleCanonical("msg B", b.acct.Owner, "", "zach@x.com/res", "id-B")
-
-	// The reply to A carries an owner 1:1 segment (stamps) and a room segment.
-	// The room segment routes via SendRoomTo (no XEP-0359 plumbing at all), so
-	// only the owner chat send is observable through onSendChat — that's the
-	// point: rooms can never carry an owner stamp.
-	ownerSends := 0
-	b.xmpp.onSendChat = func(to, text, replyTo string) {
-		ownerSends++
-		if bareJid(to) != b.acct.Owner {
-			t.Errorf("onSendChat fired for non-owner %q — rooms must use SendRoomTo", to)
-		}
-		if replyTo != "id-A" {
-			t.Errorf("owner segment: replyTo = %q, want id-A", replyTo)
-		}
-	}
-	b.deliverReply("to: zach@x.com\nfor A\nto: team@muc.x.com\nroom note")
-	if ownerSends != 1 {
-		t.Errorf("deliverReply made %d owner chat sends, want 1", ownerSends)
-	}
-
-	// B's run drains the backlog — its owner segment must not stamp.
-	b.handleRPCEvent(Event{"type": "agent_start"})
-	b.xmpp.onSendChat = func(to, text, replyTo string) {
-		if bareJid(to) == b.acct.Owner && replyTo != "" {
-			t.Errorf("drained run: owner replyTo = %q, want \"\"", replyTo)
-		}
-	}
-	b.deliverReply("to: zach@x.com\nfor B")
-}
-
 // nopClose adapts a bytes.Buffer to io.WriteCloser for RPCClient.stdin.
 type nopClose struct{ buf *bytes.Buffer }
 

--- a/xmpp.go
+++ b/xmpp.go
@@ -1148,29 +1148,13 @@ func (b *XMPPBridge) Send(text string) string { return b.SendChatTo(b.acct.Owner
 // SendChatTo posts a 1:1 chat message to an arbitrary JID, splitting long text.
 // Returns the stanza ID of the last chunk sent, or "" if nothing was sent.
 func (b *XMPPBridge) SendChatTo(to, text string) string {
-	return b.sendChat(to, text, "")
-}
-
-// SendChatToReplyTo posts a 1:1 chat message carrying a XEP-0359 <reply>
-// element referencing the stanza ID of the owner message it answers (""
-// disables the stamp). Used to thread replies to one of several messages sent
-// before any reply.
-func (b *XMPPBridge) SendChatToReplyTo(text, replyTo string) string {
-	return b.sendChat(b.acct.Owner, text, replyTo)
-}
-
-func (b *XMPPBridge) sendChat(to, text, replyTo string) string {
 	if b.currentSession() == nil {
 		b.log("warning", "send skipped: not online")
 		return ""
 	}
 	var lastID string
-	for i, part := range chunk(text, maxBody) {
-		rt := replyTo
-		if i > 0 {
-			rt = "" // only the first chunk of a split reply carries the thread stamp
-		}
-		id, err := b.encodeChat(to, part, stanza.ChatMessage, rt)
+	for _, part := range chunk(text, maxBody) {
+		id, err := b.encodeChat(to, part, stanza.ChatMessage)
 		if err != nil {
 			b.log("error", "send failed: "+err.Error())
 			break
@@ -1320,7 +1304,7 @@ func (b *XMPPBridge) currentSession() *xmpp.Session {
 
 // --- stanza encoders ---
 
-func (b *XMPPBridge) encodeChat(to, body string, typ stanza.MessageType, replyTo string) (string, error) {
+func (b *XMPPBridge) encodeChat(to, body string, typ stanza.MessageType) (string, error) {
 	session := b.currentSession()
 	if session == nil {
 		return "", fmt.Errorf("not online")
@@ -1332,26 +1316,15 @@ func (b *XMPPBridge) encodeChat(to, body string, typ stanza.MessageType, replyTo
 	id := newStanzaID()
 	msg := struct {
 		stanza.Message
-		Body  string     `xml:"body"`
-		Reply *replyElem `xml:",omitempty"`
+		Body string `xml:"body"`
 	}{
 		Message: stanza.Message{ID: id, To: toJID, Type: typ},
 		Body:    body,
-	}
-	if replyTo != "" {
-		msg.Reply = &replyElem{To: replyTo}
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	b.recordMessage(id, to)
 	return id, b.encode(ctx, session, msg)
-}
-
-// replyElem is the XEP-0359 stanza-identification reply element: minimal form
-// of "this message is a reply to message <to>".
-type replyElem struct {
-	XMLName xml.Name `xml:"urn:xmpp:reply:0 reply"`
-	To      string   `xml:"to,attr"`
 }
 
 func (b *XMPPBridge) encodeChatState(to, state string, typ stanza.MessageType) error {
@@ -1747,7 +1720,7 @@ func (b *XMPPBridge) SendRoomTo(room, text string) string {
 	}
 	var lastID string
 	for _, part := range chunk(text, maxBody) {
-		id, err := b.encodeChat(room, part, stanza.GroupChatMessage, "")
+		id, err := b.encodeChat(room, part, stanza.GroupChatMessage)
 		if err != nil {
 			b.log("error", "room send failed: "+err.Error())
 			break

--- a/xmpp.go
+++ b/xmpp.go
@@ -292,12 +292,6 @@ type XMPPBridge struct {
 	onMsg     func(InboundMessage)
 	logf      func(level, msg string)
 
-	// onSendChat records a chat-send routing decision (test hook): called once
-	// per sendChat with the destination, last chunk, and the XEP-0359 reply
-	// target. Fires before the online check so route selection (stamped vs
-	// plain) is observable without a live session.
-	onSendChat func(to, text, replyTo string)
-
 	mu       sync.Mutex
 	session  *xmpp.Session
 	online   bool
@@ -1161,14 +1155,11 @@ func (b *XMPPBridge) SendChatTo(to, text string) string {
 // element referencing the stanza ID of the owner message it answers (""
 // disables the stamp). Used to thread replies to one of several messages sent
 // before any reply.
-func (b *XMPPBridge) SendChatToReplyTo(to, text, replyTo string) string {
-	return b.sendChat(to, text, replyTo)
+func (b *XMPPBridge) SendChatToReplyTo(text, replyTo string) string {
+	return b.sendChat(b.acct.Owner, text, replyTo)
 }
 
 func (b *XMPPBridge) sendChat(to, text, replyTo string) string {
-	if b.onSendChat != nil {
-		b.onSendChat(to, text, replyTo)
-	}
 	if b.currentSession() == nil {
 		b.log("warning", "send skipped: not online")
 		return ""

--- a/xmpp_test.go
+++ b/xmpp_test.go
@@ -123,29 +123,6 @@ func TestReceiptAckMarshal(t *testing.T) {
 	}
 }
 
-// replyEl / replyPayload mirror the wire struct built by encodeChat when a
-// XEP-0359 reply target is set, so the threaded-reply form can be asserted
-// without a live session.
-func replyPayload(forID string) any {
-	return struct {
-		XMLName xml.Name
-		To      string `xml:"to,attr"`
-	}{XMLName: xml.Name{Space: "urn:xmpp:reply:0", Local: "reply"}, To: forID}
-}
-
-func TestReplyMarshal(t *testing.T) {
-	out, err := xml.Marshal(replyPayload("msg-42"))
-	if err != nil {
-		t.Fatalf("marshal reply: %v", err)
-	}
-	got := string(out)
-	for _, want := range []string{"<reply", `xmlns="urn:xmpp:reply:0"`, `to="msg-42"`} {
-		if !strings.Contains(got, want) {
-			t.Errorf("reply payload = %q, missing %q", got, want)
-		}
-	}
-}
-
 // reactionEl / reactionsPayload mirror the wire struct built by encodeReaction,
 // so the XEP-0444 form can be asserted without a live session.
 type reactionEl struct {


### PR DESCRIPTION
Reverts the XEP-0359 1:1 reply-stamp feature (PR #50 + #51). The owner evaluated it live and it failed: the stamp never fired in practice, and the real bottleneck was turn shape (tool-only runs ending empty), not the stamp. Restoring pre-feature `main` exactly (c77026b), verified via `git diff c77026b HEAD` = empty and green build/vet/test.