### PR TITLE
fix: never let a reply vanish silently

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,15 @@ sequenceDiagram
 - Agent state shows on three independent signals (1:1): a **typing indicator** while a
   reply is actually being written, presence **`<show>`** (`dnd` while busy, available
   when idle), and a presence **status** label of the current activity (`thinking…`,
-  `running: <cmd>`, `replying…`, `retrying…`, `listening`). When a run settles with
-  **no** text you get a `✅ done (no reply) — your turn` nudge.
+  `running: <cmd>`, `replying…`, `retrying…`, `listening`). When a run settles
+  without delivering anything you get a `✅ done (no reply) — your turn` nudge.
+  A reply that was written but could not be routed does **not** count as
+  delivered, so a dropped reply still raises the nudge instead of passing as an
+  answer.
+- **Empty-tail recovery**: when a run ends on a tool call with no reply text
+  after it, the answer was never written and nothing can be sent. The bridge
+  asks the agent once per turn to write the reply, then falls back to the
+  `done (no reply)` nudge if that also produces nothing.
 - Messages you send are acknowledged with a single **read receipt** — a XEP-0333
   chat marker (`displayed`) — when the agent takes them in, if your client requests it.
 - Your chat messages → routed to Pi:

--- a/bridge.go
+++ b/bridge.go
@@ -64,9 +64,18 @@ type Bridge struct {
 	turnDest       string        // reply destination for the current turn (owner or room jid)
 	routingSeeded  bool          // the pi-msg routing contract has been injected into this session (once)
 	reactionAckRun bool          // a run was woken by an inbound reaction ack (suppress "done (no reply)" noise)
-	idleSince      time.Time     // when the agent last became idle; zero while a run is in flight
-	awayAnnounced  bool          // the away transition has been announced this idle period
-	lastAwayStatus string        // the last pithy activity shown while away (skip repeats across periods)
+	// finalMsgHadText records whether the most recent assistant message of this
+	// run carried deliverable text. A run that ends on a tool call leaves it
+	// false: the answer was never written, so nothing could be delivered.
+	finalMsgHadText bool
+	// toolSinceDelivery records that a tool ran after the last successful
+	// delivery. With finalMsgHadText it separates a run that stopped mid-work
+	// from one that deliberately said nothing (to: noop).
+	toolSinceDelivery bool
+	tailNudges        int       // empty-tail recovery prompts sent this user turn (bounded)
+	idleSince         time.Time // when the agent last became idle; zero while a run is in flight
+	awayAnnounced     bool      // the away transition has been announced this idle period
+	lastAwayStatus    string    // the last pithy activity shown while away (skip repeats across periods)
 
 	lifecycleReactTo string // snapshot of reactTo at run start, for lifecycle auto-reacts
 	lifecycleReactID string // snapshot of reactID at run start; never overwritten by deliverReply
@@ -350,6 +359,7 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		b.setReplied(false)
 		b.setHandleWarned(false)
 		b.clearPendingNudge() // a new run starts — discard any stale staged correction (#16)
+		b.resetTailTracking() // fresh run: no message seen, no tool since delivery
 		b.reactionAckRun = false
 		b.markActive() // a run is in flight — not idle
 		b.xmpp.SetPresence("dnd", "thinking…")
@@ -365,11 +375,17 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		// the run's FINAL message was malformed (pending nudge set AND nothing
 		// successfully delivered after it). Not before.
 		b.firePendingNudge()
+		// A run that ended on a tool call never wrote its answer: the tool
+		// result came back and no assistant text followed it. Ask for the reply
+		// once rather than letting the work vanish. A deliberate silence uses
+		// "to: noop", which delivers and so never reaches here.
+		recovering := b.needsEmptyTailRecovery() && b.fireTailRecovery()
 		// The reply text + typing/presence already signal "done". Only nudge if
 		// the run produced no message, so silence isn't mistaken for a hang.
 		// A run woken purely by a reaction ack (reactionAckRun) is allowed to
-		// stay silent after a to:noop without spamming the owner.
-		if !b.replied() && !b.volunteered && !b.reactionAckRun {
+		// stay silent after a to:noop without spamming the owner. A recovery
+		// prompt is in flight, so hold the banner: the retry may still answer.
+		if !b.replied() && !b.volunteered && !b.reactionAckRun && !recovering {
 			b.reply("✅ done (no reply) — your turn")
 		}
 		b.volunteered = false // a resume volunteer turn is a one-shot; never repeats
@@ -379,6 +395,7 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		// A tool is running, not text streaming: drop the typing bubble and
 		// label the activity.
 		b.stopTyping()
+		b.markToolSinceDelivery()
 		b.xmpp.SetPresence("dnd", toolLabel(ev))
 	case "auto_retry_start":
 		b.stopTyping()
@@ -397,9 +414,21 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		if msg == nil || msg.Str("role") != "assistant" {
 			return
 		}
-		if text := FixToolCallXML(extractText(msg["content"])); text != "" {
-			b.deliverReply(text)
+		// Record whether THIS message carried text before delivering it: at
+		// settle, only the last message's answer matters, and a run whose final
+		// message is tool-only never wrote its reply at all.
+		text := FixToolCallXML(extractText(msg["content"]))
+		b.setFinalMsgHadText(text != "")
+		if text == "" {
+			return
+		}
+		// "replied" must mean "reached a destination", not "text existed".
+		// A malformed reply goes to the error room, which the owner never
+		// reads — counting that as a reply would suppress the settle-time
+		// "done (no reply)" banner and leave the owner with silence.
+		if b.deliverReply(text) {
 			b.setReplied(true)
+			b.clearToolSinceDelivery()
 		}
 	case "extension_error":
 		b.reply("⚠️ extension error: " + orUnknown(ev.Str("error")))
@@ -530,6 +559,7 @@ func (b *Bridge) handleToolRelay(id, payload string) {
 // stream.
 func (b *Bridge) onInbound(m InboundMessage) {
 	b.resetRoutingNudges() // fresh user turn — allow corrections again
+	b.resetTailNudges()    // fresh user turn — allow one empty-tail recovery again
 	// Any inbound message is activity: come back to available and restart the
 	// idle-away timer from now (a run still in flight keeps dnd — leave its
 	// presence alone).
@@ -1553,7 +1583,8 @@ func (b *Bridge) reply(text string) {
 // known occupant → 1:1. Text with no "to:" line, text before the first "to:",
 // or a non-allowlisted target is forwarded to the owner with a note and the
 // agent is nudged to resend correctly.
-func (b *Bridge) deliverReply(text string) {
+func (b *Bridge) deliverReply(text string) bool {
+	delivered := false
 	if !b.acct.RoomMode() {
 		// Deliberate reactions are the send_reaction tool's job now; a 1:1 reply
 		// is just its text.
@@ -1563,16 +1594,17 @@ func (b *Bridge) deliverReply(text string) {
 			// send_reaction calls target the agent's own message.
 			if stanzaID != "" {
 				b.setReactTarget(b.acct.Owner, stanzaID)
+				delivered = true
 			}
 		}
-		return
+		return delivered
 	}
 	segs, leading := splitReplySegments(text)
 	if len(segs) == 0 {
 		if body := strings.TrimSpace(text); body != "" {
 			b.rejectReply(body, "it had no \"to: <jid>\" routing line")
 		}
-		return
+		return false
 	}
 	if leading != "" {
 		b.rejectReply(leading, "this text came before the first \"to:\" line, so it had no destination")
@@ -1589,6 +1621,9 @@ func (b *Bridge) deliverReply(text string) {
 			b.log("notice", "agent chose silence (to: noop)")
 			b.clearPendingNudge()
 			b.setReplied(true)
+			// Deliberate silence IS an answer: it must not look like a run that
+			// died before writing one, or the recovery would argue with it.
+			delivered = true
 			continue
 		}
 		kind := b.xmpp.classifyDest(s.dest)
@@ -1612,6 +1647,7 @@ func (b *Bridge) deliverReply(text string) {
 			// "a later message routed fine" discards the staged nudge).
 			if stanzaID != "" {
 				b.clearPendingNudge()
+				delivered = true
 			}
 			// Update reaction target to the last-segment message so subsequent
 			// send_reaction calls target the agent's own most recent message.
@@ -1624,6 +1660,7 @@ func (b *Bridge) deliverReply(text string) {
 			}
 		}
 	}
+	return delivered
 }
 
 // maxRoutingNudges bounds how many routing reminders we send per user turn, so
@@ -1682,6 +1719,91 @@ func (b *Bridge) takeStagedNudge() string {
 		return ""
 	}
 	return p.reason
+}
+
+// maxTailNudges bounds how many empty-tail recovery prompts we send per user
+// turn. One retry recovers the common case; more would loop against a model
+// that keeps ending its runs on a tool call.
+const maxTailNudges = 1
+
+// resetTailTracking clears the empty-tail bookkeeping at the start of a run.
+func (b *Bridge) resetTailTracking() {
+	b.mu.Lock()
+	b.finalMsgHadText = false
+	b.toolSinceDelivery = false
+	b.mu.Unlock()
+}
+
+// setFinalMsgHadText records whether the assistant message that just ended
+// carried deliverable text. Only the last such call before settle matters.
+func (b *Bridge) setFinalMsgHadText(v bool) {
+	b.mu.Lock()
+	b.finalMsgHadText = v
+	b.mu.Unlock()
+}
+
+// markToolSinceDelivery notes that a tool started after the last delivery, so
+// the run has work in flight that an answer should still report on.
+func (b *Bridge) markToolSinceDelivery() {
+	b.mu.Lock()
+	b.toolSinceDelivery = true
+	b.mu.Unlock()
+}
+
+// clearToolSinceDelivery is called when a reply actually reaches a destination:
+// the work up to this point has been reported.
+func (b *Bridge) clearToolSinceDelivery() {
+	b.mu.Lock()
+	b.toolSinceDelivery = false
+	b.mu.Unlock()
+}
+
+// needsEmptyTailRecovery reports whether the run stopped mid-work: a tool ran
+// after the last delivered text, and the run's final assistant message carried
+// no text at all. That combination means the answer was never written — the
+// bridge has nothing to send and the owner would see silence.
+//
+// A run that delivered its reply after the tool clears toolSinceDelivery, so it
+// never matches. Nor does a run that simply had nothing to do (no tool). A
+// volunteer or reaction-ack run is allowed to end quietly.
+func (b *Bridge) needsEmptyTailRecovery() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.volunteered || b.reactionAckRun {
+		return false
+	}
+	return b.toolSinceDelivery && !b.finalMsgHadText
+}
+
+// bumpTailNudge consumes one unit of the per-turn recovery budget.
+func (b *Bridge) bumpTailNudge() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.tailNudges++
+	return b.tailNudges <= maxTailNudges
+}
+
+// resetTailNudges refills the recovery budget at the start of a user turn.
+func (b *Bridge) resetTailNudges() { b.mu.Lock(); b.tailNudges = 0; b.mu.Unlock() }
+
+// fireTailRecovery asks the agent for the reply its run never wrote. It reports
+// whether a prompt went out, so the caller can hold the "done (no reply)"
+// banner while the retry is in flight. Returns false once the budget is spent,
+// and the banner then tells the owner nothing came back.
+func (b *Bridge) fireTailRecovery() bool {
+	if !b.bumpTailNudge() {
+		return false
+	}
+	b.log("notice", "run ended on a tool call with no reply: asking the agent to write it")
+	// A pure 1:1 account has no routing contract, so don't ask it for a "to:"
+	// line it must not write.
+	const base = "Your last run ended after a tool call without writing any reply, so nothing was delivered to the chat. The tool result is above. Write the reply now."
+	prompt := base
+	if b.acct.RoomMode() {
+		prompt = fmt.Sprintf("%s Begin it with a \"to: <jid>\" line (e.g. \"to: %s\" for the owner). If you truly have nothing to say, reply with \"to: noop\".", base, b.acct.Owner)
+	}
+	b.rpc.Prompt(prompt, b.steerBehavior())
+	return true
 }
 
 // firePendingNudge sends the staged routing reminder, if the run settled on a
@@ -2238,6 +2360,9 @@ func (b *Bridge) settleLocally() {
 	b.markIdle()
 	b.xmpp.SetPresence("", "listening")
 	b.clearPendingNudge() // aborted run — discard any staged correction (#16)
+	// Aborted or replaced run: drop the empty-tail bookkeeping so a recovery
+	// prompt can't fire for work the user already cancelled.
+	b.resetTailTracking()
 }
 
 // idleAwayTimeout is how long the agent may sit idle before its presence

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -611,3 +611,129 @@ func TestOpenRouterCreditsParse(t *testing.T) {
 		t.Fatalf("got total=%v used=%v, want 85 / 81.11", total, used)
 	}
 }
+
+// newTestBridge builds an offline bridge: sends return "" (not online), which
+// is exactly the "nothing reached a destination" case deliverReply must report.
+func newTestBridge(acct ResolvedAccount) *Bridge {
+	b := NewBridge(acct, false)
+	b.xmpp = NewXMPPBridge(acct, func(InboundMessage) {}, b.log)
+	return b
+}
+
+// TestRepliedOnlyOnDelivery pins the core of the dropped-reply fix: "replied"
+// must mean "reached a destination", not "text existed". A malformed reply goes
+// to the write-only error room, which the owner never reads, so counting it as
+// a reply would suppress the settle-time banner and leave the owner in silence.
+func TestRepliedOnlyOnDelivery(t *testing.T) {
+	room := ResolvedAccount{Rooms: []string{"team@muc.x"}, ErrorRoom: "errors@muc.x", Owner: "zach@x"}
+	b := newTestBridge(room)
+	if b.deliverReply("no routing line here") {
+		t.Error("a reply with no \"to:\" line must not count as delivered")
+	}
+	if b.deliverReply("to: errors@muc.x\n\nsneaky") {
+		t.Error("a blocked destination must not count as delivered")
+	}
+	// Offline: a well-formed reply still can't reach anyone.
+	if b.deliverReply("to: zach@x\n\nhello") {
+		t.Error("an offline send must not count as delivered")
+	}
+	// Pure 1:1 accounts take the other branch; offline is still not delivered.
+	solo := newTestBridge(ResolvedAccount{Owner: "zach@x"})
+	if solo.deliverReply("hello") {
+		t.Error("an offline 1:1 send must not count as delivered")
+	}
+}
+
+// TestNoopStillCountsAsReplied verifies deliberate silence stays an answer:
+// "to: noop" emits no stanza but must never look like a run that died before
+// writing a reply, or the empty-tail recovery would argue with it.
+func TestNoopStillCountsAsReplied(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Rooms: []string{"team@muc.x"}, Owner: "zach@x"})
+	if !b.deliverReply("to: noop\n\nnothing to add") {
+		t.Error("to: noop must count as delivered")
+	}
+	if !b.replied() {
+		t.Error("to: noop must set replied")
+	}
+}
+
+// TestPreambleDoesNotDisarmNoReplyNet covers the failure that dropped replies
+// live: the agent writes a preamble alongside its tool call, the tool returns,
+// and the run ends with no further text. The delivered preamble used to mark
+// the run as answered, so no banner and no retry fired — the owner just got a
+// "running…" line and then silence.
+func TestPreambleDoesNotDisarmNoReplyNet(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Rooms: []string{"team@muc.x"}, Owner: "zach@x"})
+	b.resetTailTracking()
+	// Preamble message: text delivered, then the tool starts.
+	b.setFinalMsgHadText(true)
+	b.clearToolSinceDelivery()
+	b.markToolSinceDelivery()
+	// The tool result arrives and the run ends with a tool-only message.
+	b.setFinalMsgHadText(false)
+	if !b.needsEmptyTailRecovery() {
+		t.Error("a run ending on a tool call after a preamble needs recovery")
+	}
+	// The winning shape: the reply text comes after the tool result.
+	b.setFinalMsgHadText(true)
+	b.clearToolSinceDelivery()
+	if b.needsEmptyTailRecovery() {
+		t.Error("a run that replied after its tool needs no recovery")
+	}
+}
+
+// TestNoRecoveryWithoutTool verifies a run that never ran a tool is left alone:
+// an empty final message there is the model saying nothing, which the existing
+// "done (no reply)" banner already covers.
+func TestNoRecoveryWithoutTool(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Owner: "zach@x"})
+	b.resetTailTracking()
+	if b.needsEmptyTailRecovery() {
+		t.Error("no tool ran — recovery must not fire")
+	}
+	// Volunteer and reaction-ack runs are allowed to end quietly even mid-work.
+	b.markToolSinceDelivery()
+	b.volunteered = true
+	if b.needsEmptyTailRecovery() {
+		t.Error("a volunteer run must not trigger recovery")
+	}
+	b.volunteered = false
+	b.reactionAckRun = true
+	if b.needsEmptyTailRecovery() {
+		t.Error("a reaction-ack run must not trigger recovery")
+	}
+}
+
+// TestEmptyTailRecoveryBounded verifies the retry can't loop against a model
+// that keeps ending its runs on a tool call: one prompt per user turn, then the
+// banner takes over and tells the owner nothing came back.
+func TestEmptyTailRecoveryBounded(t *testing.T) {
+	b := NewBridge(ResolvedAccount{}, false)
+	for i := 1; i <= maxTailNudges; i++ {
+		if !b.bumpTailNudge() {
+			t.Errorf("recovery %d should be allowed (cap %d)", i, maxTailNudges)
+		}
+	}
+	if b.bumpTailNudge() {
+		t.Error("recovery past the cap should be denied")
+	}
+	b.resetTailNudges()
+	if !b.bumpTailNudge() {
+		t.Error("after a fresh user turn, recovery should be allowed again")
+	}
+}
+
+// TestSettleLocallyClearsTailTracking verifies an aborted or replaced run can't
+// leave state behind that fires a recovery prompt for cancelled work.
+func TestSettleLocallyClearsTailTracking(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Owner: "zach@x"})
+	b.markToolSinceDelivery()
+	b.setFinalMsgHadText(false)
+	if !b.needsEmptyTailRecovery() {
+		t.Fatal("precondition: mid-work run should need recovery")
+	}
+	b.settleLocally()
+	if b.needsEmptyTailRecovery() {
+		t.Error("settleLocally must clear the empty-tail bookkeeping")
+	}
+}


### PR DESCRIPTION
Problem 1 from the 2026-09-01 session post-mortem: replies to owner messages could disappear with no signal to the owner. This is independent of the reverted XEP-0359 reply-stamp work (PRs #50/#51/#52) and touches none of it.

## Defects

**D-a / D-b — the run ends on a tool call.** `message_end` delivers only when `extractText` is non-empty. A `[thinking + toolCall]` tail delivers nothing. The `✅ done (no reply)` net at `agent_settled` fires only when `!replied()`, but `setReplied(true)` ran on *any* text in the run — including the "On it — running…" preamble written in the same message as the tool call. So the exact failing shape was the one shape where the net stayed silent. The owner got a preamble and then nothing.

**D-c — delivery failure counted as a reply.** `message_end` called `deliverReply(text)` and then set replied unconditionally, even when every segment was rejected.

## Fix

1. `deliverReply` returns whether any segment reached a destination. `message_end` sets `repliedThisRun` only on a real delivery. `to: noop` still counts as delivered — deliberate silence is an answer. A reject-only run now reaches settle with `replied() == false`, so the banner fires and the malformed body stays in the error room where it belongs.

2. New run-scoped state: `toolSinceDelivery` (a tool started after the last successful delivery) and `finalMsgHadText` (the most recent assistant message carried text). The pair identifies a run that stopped mid-work. At `agent_settled` the bridge asks the agent once per user turn to write the reply, and holds the banner while that retry is in flight. `maxTailNudges = 1` bounds it; `resetTailNudges` refills on each inbound message. Volunteer and reaction-ack runs are exempt. `settleLocally` clears the bookkeeping so an aborted run cannot trigger a recovery for cancelled work.

The recovery prompt omits the `to:` instruction on pure-1:1 accounts, which have no routing contract.

## Tests

- `TestRepliedOnlyOnDelivery` — no routing line, blocked destination, and offline sends all report undelivered, in both room and 1:1 mode.
- `TestNoopStillCountsAsReplied` — `to: noop` delivers and sets replied.
- `TestPreambleDoesNotDisarmNoReplyNet` — the exact live failure: preamble delivered, tool runs, tool-only tail → recovery needed. Reply-after-tool → no recovery.
- `TestNoRecoveryWithoutTool` — no tool, volunteer run, and reaction-ack run never recover.
- `TestEmptyTailRecoveryBounded` — one prompt per turn, then the banner.
- `TestSettleLocallyClearsTailTracking` — abort clears the state.

`go build`, `go vet`, `go test ./...` all pass. `go test -race` has 7 pre-existing races and one pre-existing failure (`TestToolRelayCarriesReason`) on `main` as well — unchanged by this branch.

## Verifying live after deploy

Send `run a 10sec command then reply A`. If the run still ends tool-only, the recovery prompt must produce the "A" reply, and `journalctl -u beltino` shows `run ended on a tool call with no reply: asking the agent to write it`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWrpAdh3EWJ1jU6sjKLV7o