### PR TITLE
fix: catch messages a steer made the agent skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ sequenceDiagram
   after it, the answer was never written and nothing can be sent. The bridge
   asks the agent once per turn to write the reply, then falls back to the
   `done (no reply)` nudge if that also produces nothing.
+- **Unanswered-message hint**: a message that arrives mid-run is injected as a
+  steer at the next yield point, usually the moment a tool result returns. The
+  agent can read the new question before it writes the answer to the previous
+  one, and then never write it. When a run takes in more messages than it sends
+  replies, the bridge asks it once per turn to check for messages that still
+  need an answer. The agent replies with those answers, or with `to: noop` if it
+  already covered everything. `to: noop` counts as an answer, so deliberate
+  silence is never flagged.
 - Messages you send are acknowledged with a single **read receipt** — a XEP-0333
   chat marker (`displayed`) — when the agent takes them in, if your client requests it.
 - Your chat messages → routed to Pi:

--- a/bridge.go
+++ b/bridge.go
@@ -1862,7 +1862,10 @@ func (b *Bridge) fireUnansweredHint(inbound, delivered int) bool {
 		return false
 	}
 	b.log("notice", fmt.Sprintf("run took %d messages and sent %d replies: asking the agent to check for unanswered ones", inbound, delivered))
-	b.rpc.Prompt(fmt.Sprintf("This run took in %d chat messages but sent %d replies. Messages that arrive while you are working are injected mid-run, so it is easy to read a new one and never answer the previous one. Check each message of this run. Send a reply for any that still needs its own answer. If you already addressed all of them, reply with \"to: noop\".", inbound, delivered), b.steerBehavior())
+	// Once "to: <stanza-id>" routing lands (issue #54), the destination form
+	// below becomes the stanza id, so each outstanding reply can name the
+	// message it answers.
+	b.rpc.Prompt(fmt.Sprintf("Received %d messages but sent %d replies. If your %d replies addressed all %d messages reply to this with \"to: noop\". If some things outstanding reply to them now using \"to: <jid>\".", inbound, delivered, delivered, inbound), b.steerBehavior())
 	return true
 }
 

--- a/bridge.go
+++ b/bridge.go
@@ -72,10 +72,20 @@ type Bridge struct {
 	// delivery. With finalMsgHadText it separates a run that stopped mid-work
 	// from one that deliberately said nothing (to: noop).
 	toolSinceDelivery bool
-	tailNudges        int       // empty-tail recovery prompts sent this user turn (bounded)
-	idleSince         time.Time // when the agent last became idle; zero while a run is in flight
-	awayAnnounced     bool      // the away transition has been announced this idle period
-	lastAwayStatus    string    // the last pithy activity shown while away (skip repeats across periods)
+	tailNudges        int // empty-tail recovery prompts sent this user turn (bounded)
+	// runInbound counts the chat messages that entered the current run: the one
+	// that started it plus every steer that landed while it was in flight.
+	// runDeliveries counts the replies that actually reached a destination. Pi
+	// injects a steer at the first yield point — typically the instant a tool
+	// result returns — so the model can read a new question before it writes the
+	// answer to the last one, and that answer is then never written at all.
+	// Comparing the two counts at settle catches exactly that.
+	runInbound     int
+	runDeliveries  int
+	hintNudges     int       // unanswered-message hints sent this user turn (bounded)
+	idleSince      time.Time // when the agent last became idle; zero while a run is in flight
+	awayAnnounced  bool      // the away transition has been announced this idle period
+	lastAwayStatus string    // the last pithy activity shown while away (skip repeats across periods)
 
 	lifecycleReactTo string // snapshot of reactTo at run start, for lifecycle auto-reacts
 	lifecycleReactID string // snapshot of reactID at run start; never overwritten by deliverReply
@@ -380,6 +390,17 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		// once rather than letting the work vanish. A deliberate silence uses
 		// "to: noop", which delivers and so never reaches here.
 		recovering := b.needsEmptyTailRecovery() && b.fireTailRecovery()
+		// Several messages entered this run but fewer replies left it. Pi
+		// injects a steer the moment a tool yields, so the model can read the
+		// next question before answering the last — and then never answer it.
+		// Ask it to check, with an explicit way to say it already did.
+		if !recovering {
+			if n, m, ok := b.unansweredRun(); ok {
+				recovering = b.fireUnansweredHint(n, m)
+			}
+		}
+		// The counts belong to the run that just ended, whatever we decided.
+		b.resetRunCounts()
 		// The reply text + typing/presence already signal "done". Only nudge if
 		// the run produced no message, so silence isn't mistaken for a hang.
 		// A run woken purely by a reaction ack (reactionAckRun) is allowed to
@@ -429,6 +450,7 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		if b.deliverReply(text) {
 			b.setReplied(true)
 			b.clearToolSinceDelivery()
+			b.countDelivery()
 		}
 	case "extension_error":
 		b.reply("⚠️ extension error: " + orUnknown(ev.Str("error")))
@@ -560,6 +582,7 @@ func (b *Bridge) handleToolRelay(id, payload string) {
 func (b *Bridge) onInbound(m InboundMessage) {
 	b.resetRoutingNudges() // fresh user turn — allow corrections again
 	b.resetTailNudges()    // fresh user turn — allow one empty-tail recovery again
+	b.resetHintNudges()    // fresh user turn — allow one unanswered-message hint again
 	// Any inbound message is activity: come back to available and restart the
 	// idle-away timer from now (a run still in flight keeps dnd — leave its
 	// presence alone).
@@ -712,6 +735,7 @@ func (b *Bridge) handleCanonical(text, origin, sender, reactTo, reactID string) 
 	// and remember where a reply (or tool-driven file) should go by default.
 	b.setLifecycleReactTarget(reactTo, reactID)
 	b.setTurnDest(origin)
+	b.countInbound()
 	b.rpc.Prompt(b.composePrompt(t, true, "", origin, sender, reactID, reactTo), b.steerBehavior())
 	b.busyPresence("thinking…")
 }
@@ -726,6 +750,7 @@ func (b *Bridge) dispatchCommentary(body, nick, origin, sender, reactTo, reactID
 	}
 	b.setLifecycleReactTarget(reactTo, reactID)
 	b.setTurnDest(origin)
+	b.countInbound()
 	b.rpc.Prompt(b.composePrompt(t, false, nick, origin, sender, reactID, reactTo), b.steerBehavior())
 	b.busyPresence("thinking…")
 }
@@ -1786,6 +1811,72 @@ func (b *Bridge) bumpTailNudge() bool {
 // resetTailNudges refills the recovery budget at the start of a user turn.
 func (b *Bridge) resetTailNudges() { b.mu.Lock(); b.tailNudges = 0; b.mu.Unlock() }
 
+// maxHintNudges bounds how many unanswered-message hints we send per user turn.
+const maxHintNudges = 1
+
+// countInbound records that a chat message entered the current run. Called for
+// the message that starts a run and for every steer that lands while it runs.
+func (b *Bridge) countInbound() { b.mu.Lock(); b.runInbound++; b.mu.Unlock() }
+
+// countDelivery records that a reply reached a destination in the current run.
+func (b *Bridge) countDelivery() { b.mu.Lock(); b.runDeliveries++; b.mu.Unlock() }
+
+// resetRunCounts clears the per-run message/reply tally. Called at settle,
+// AFTER the decision, and on an aborted run.
+//
+// The counters are reset at settle rather than at agent_start because
+// handleCanonical counts a message before pi reports the run started: resetting
+// at agent_start would zero the very message that opened the run.
+func (b *Bridge) resetRunCounts() {
+	b.mu.Lock()
+	b.runInbound = 0
+	b.runDeliveries = 0
+	b.mu.Unlock()
+}
+
+// unansweredRun reports whether the run took in more messages than it answered,
+// and returns both counts. It only fires when at least two messages entered the
+// run: a single message with no reply is the empty-tail case, already covered by
+// needsEmptyTailRecovery and the "done (no reply)" banner.
+//
+// "to: noop" counts as a delivery, so a run the agent deliberately answered with
+// silence is never flagged.
+func (b *Bridge) unansweredRun() (inbound, delivered int, ok bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.volunteered || b.reactionAckRun {
+		return 0, 0, false
+	}
+	return b.runInbound, b.runDeliveries, b.runInbound > 1 && b.runInbound > b.runDeliveries
+}
+
+// fireUnansweredHint asks the agent to check whether any message of the run
+// still needs its own reply. It reports whether a prompt went out so the caller
+// can hold the "done (no reply)" banner while the check is in flight.
+//
+// The hint is a prompt, not a chat message: it never reaches the owner. The
+// agent answers it with real replies, or with "to: noop" if it already covered
+// everything — so a correctly-handled run costs one cheap turn and no noise.
+func (b *Bridge) fireUnansweredHint(inbound, delivered int) bool {
+	if !b.bumpHintNudge() {
+		return false
+	}
+	b.log("notice", fmt.Sprintf("run took %d messages and sent %d replies: asking the agent to check for unanswered ones", inbound, delivered))
+	b.rpc.Prompt(fmt.Sprintf("This run took in %d chat messages but sent %d replies. Messages that arrive while you are working are injected mid-run, so it is easy to read a new one and never answer the previous one. Check each message of this run. Send a reply for any that still needs its own answer. If you already addressed all of them, reply with \"to: noop\".", inbound, delivered), b.steerBehavior())
+	return true
+}
+
+// bumpHintNudge consumes one unit of the per-turn hint budget.
+func (b *Bridge) bumpHintNudge() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.hintNudges++
+	return b.hintNudges <= maxHintNudges
+}
+
+// resetHintNudges refills the hint budget at the start of a user turn.
+func (b *Bridge) resetHintNudges() { b.mu.Lock(); b.hintNudges = 0; b.mu.Unlock() }
+
 // fireTailRecovery asks the agent for the reply its run never wrote. It reports
 // whether a prompt went out, so the caller can hold the "done (no reply)"
 // banner while the retry is in flight. Returns false once the budget is spent,
@@ -2363,6 +2454,7 @@ func (b *Bridge) settleLocally() {
 	// Aborted or replaced run: drop the empty-tail bookkeeping so a recovery
 	// prompt can't fire for work the user already cancelled.
 	b.resetTailTracking()
+	b.resetRunCounts()
 }
 
 // idleAwayTimeout is how long the agent may sit idle before its presence

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -737,3 +737,100 @@ func TestSettleLocallyClearsTailTracking(t *testing.T) {
 		t.Error("settleLocally must clear the empty-tail bookkeeping")
 	}
 }
+
+// TestUnansweredRunCounts covers the steer drop seen live: five messages went
+// into one run and only the last one got an answer, because pi injects each
+// queued message the instant a tool yields and the model moves on to it.
+func TestUnansweredRunCounts(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Owner: "zach@x"})
+	// The live A–E burst: 5 messages in, 1 reply out.
+	for range 5 {
+		b.countInbound()
+	}
+	b.countDelivery()
+	in, out, ok := b.unansweredRun()
+	if !ok || in != 5 || out != 1 {
+		t.Errorf("A–E burst = (%d,%d,%v), want (5,1,true)", in, out, ok)
+	}
+	// Every message answered → silent.
+	b.resetRunCounts()
+	for range 3 {
+		b.countInbound()
+		b.countDelivery()
+	}
+	if _, _, ok := b.unansweredRun(); ok {
+		t.Error("a run that answered every message must not hint")
+	}
+	// A single unanswered message is the empty-tail case, not this one: the
+	// "done (no reply)" banner and the tail recovery already cover it.
+	b.resetRunCounts()
+	b.countInbound()
+	if _, _, ok := b.unansweredRun(); ok {
+		t.Error("a single-message run must not hint")
+	}
+	// Volunteer and reaction-ack runs stay quiet even when unbalanced.
+	b.resetRunCounts()
+	b.countInbound()
+	b.countInbound()
+	b.volunteered = true
+	if _, _, ok := b.unansweredRun(); ok {
+		t.Error("a volunteer run must not hint")
+	}
+	b.volunteered = false
+	b.reactionAckRun = true
+	if _, _, ok := b.unansweredRun(); ok {
+		t.Error("a reaction-ack run must not hint")
+	}
+}
+
+// TestUnansweredHintBounded verifies the hint can't loop: one per user turn,
+// refilled when the next message arrives.
+func TestUnansweredHintBounded(t *testing.T) {
+	b := NewBridge(ResolvedAccount{}, false)
+	for i := 1; i <= maxHintNudges; i++ {
+		if !b.bumpHintNudge() {
+			t.Errorf("hint %d should be allowed (cap %d)", i, maxHintNudges)
+		}
+	}
+	if b.bumpHintNudge() {
+		t.Error("hint past the cap should be denied")
+	}
+	b.resetHintNudges()
+	if !b.bumpHintNudge() {
+		t.Error("after a fresh user turn, a hint should be allowed again")
+	}
+}
+
+// TestNoopCountsTowardAnsweredRun verifies deliberate silence balances the
+// tally, so a run the agent answered with "to: noop" is never nagged.
+func TestNoopCountsTowardAnsweredRun(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Rooms: []string{"team@muc.x"}, Owner: "zach@x"})
+	b.countInbound()
+	b.countInbound()
+	if !b.deliverReply("to: zach@x\n\nanswered one") {
+		// Offline, so this send reports undelivered; count it by hand to model
+		// the online case.
+		b.countDelivery()
+	}
+	if b.deliverReply("to: noop\n\nnothing more to add") {
+		b.countDelivery()
+	}
+	if _, _, ok := b.unansweredRun(); ok {
+		t.Error("a run answered with a reply plus to: noop must not hint")
+	}
+}
+
+// TestSettleClearsRunCounts verifies an aborted run can't carry its tally into
+// the next one and fire a hint for cancelled work.
+func TestSettleClearsRunCounts(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Owner: "zach@x"})
+	b.countInbound()
+	b.countInbound()
+	if _, _, ok := b.unansweredRun(); !ok {
+		t.Fatal("precondition: 2 in / 0 out should hint")
+	}
+	b.settleLocally()
+	if _, _, ok := b.unansweredRun(); ok {
+		t.Error("settleLocally must clear the run tally")
+	}
+}


### PR DESCRIPTION
## Evidence

Session `01a060f4`, 2026-09-02 07:10 UTC, running `3ncnkdi6…` — the binary from #53, started 07:09:16 UTC, 82 seconds before the test. Five messages, one answer:

```
07:11:00.984  toolResult  (A's sleep returns)
07:11:00.985  user        "sleep 10 then reply to this with B"
07:11:16.159  toolResult  (B's sleep returns)
07:11:16.160  user        "...with C"
```

Five times, a 1ms gap. Only E got a reply. When asked, the model produced A–D immediately — the capability was never missing.

## Mechanism

`handleCanonical` does not queue. It calls `rpc.Prompt` with `steerBehavior()`, which returns `"steer"` whenever a run is in flight, so pi injects the message at the first yield point — the instant the tool result returns. The model reads a fresh question before writing the answer to the previous one, and then never writes it.

The run never settles between messages. So the empty-tail recovery from #53 cannot see this: the only `agent_settled` comes after E, and by then `finalMsgHadText` is true. #53 is live, correct, and blind to this shape.

## Fix

Count messages in and replies out.

- `runInbound` — messages that entered the run: the one that started it plus every steer.
- `runDeliveries` — replies that reached a destination.

At `agent_settled`, when two or more messages came in and fewer replies went out, prompt the agent once per user turn:

> This run took in N chat messages but sent M replies. Messages that arrive while you are working are injected mid-run, so it is easy to read a new one and never answer the previous one. Check each message of this run. Send a reply for any that still needs its own answer. If you already addressed all of them, reply with `"to: noop"`.

It is a prompt, never a chat message, so it never reaches the owner.

Against the live case: 5 in, 1 out → fires, and the model demonstrably produces A–D at that point.

## Boundaries

- `to: noop` counts as a delivery, so a run deliberately answered with silence is never flagged.
- A single unanswered message needs two or more to fire — that case belongs to the empty-tail recovery and the `done (no reply)` banner.
- Volunteer and reaction-ack runs are exempt.
- Bounded at one hint per user turn (`maxHintNudges`), refilled on the next inbound message. The hint's own run has `runInbound == 0`, so it cannot re-trigger itself.
- Counts reset at settle **after** the decision, and in `settleLocally` for an aborted run. They cannot reset at `agent_start`: `handleCanonical` counts a message before pi reports the run started, so resetting there would zero the message that opened the run.

## Cost

An extra model turn on any run where messages and replies do not balance — including a correction steer the agent folded into one reply. Bounded, and `to: noop` makes the answer cheap, but it is not free.

## Tests

- `TestUnansweredRunCounts` — the live A–E shape (5 in, 1 out) fires; a balanced run, a single-message run, and volunteer/reaction-ack runs stay silent.
- `TestUnansweredHintBounded` — one per turn, refilled on the next message.
- `TestNoopCountsTowardAnsweredRun` — a reply plus `to: noop` balances the tally.
- `TestSettleClearsRunCounts` — an aborted run cannot carry its tally forward.

`go build`, `go vet`, `go test ./...` pass. `go test -race` has the same 7 pre-existing races and `TestToolRelayCarriesReason` failure as `main`.

## Still open

This is a safety net, not a cure. Two things remain worth doing:

- **#54** — `to: <stanza-id>` routing, so each recovered reply can name the message it answers.
- **Model swap.** This account runs `~deepseek/deepseek-v4-flash-latest`. A model that answers each message before reading the next needs no net at all. Worth running the identical A–E burst on a stronger model to see how much of this is discipline rather than architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWrpAdh3EWJ1jU6sjKLV7o