### PR TITLE
feat: route a reply by stanza id and stamp it (XEP-0461)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,12 @@ sequenceDiagram
   agent can read the new question before it writes the answer to the previous
   one, and then never write it. When a run takes in more messages than it sends
   replies, the bridge asks it once per turn to check for messages that still
-  need an answer. The agent replies with those answers, or with `to: noop` if it
-  already covered everything. `to: noop` counts as an answer, so deliberate
-  silence is never flagged.
+  need an answer. The hint asks for `to: <jid|stanza-id>` and prefers the
+  stanza id, which is exactly the case a bare JID cannot disambiguate: an id
+  both routes the reply and marks it as a reply to the message it answers. The
+  agent replies with those answers, or with `to: noop` if it already covered
+  everything. `to: noop` counts as an answer, so deliberate silence is never
+  flagged.
 - Messages you send are acknowledged with a single **read receipt** — a XEP-0333
   chat marker (`displayed`) — when the agent takes them in, if your client requests it.
 - Your chat messages → routed to Pi:

--- a/README.md
+++ b/README.md
@@ -156,13 +156,16 @@ the message's origin:
 ```
 from: <channel jid>     # the room (group msg) or the owner (DM) — reply here to answer in place
 sender: <person jid>    # room messages only, when the real JID is known — reply here to DM them
+stanza-id: <uuid>       # this message's id — reply here to answer this message specifically
 <message body>
 ```
 
-And **every** agent reply must begin with a `to: <jid>` line naming its destination:
+And **every** agent reply must begin with a `to:` line naming its destination:
 
 - `to: <room jid>` → the group chat (groupchat)
 - `to: <owner or occupant jid>` → that person, 1:1
+- `to: <stanza-id>` → the author of that message, with the reply **stamped** to it
+- `to: noop` → send nothing (deliberate silence)
 
 One reply may contain **several `to:` blocks** — each `to:` line starts a new message, so
 the agent can fan a single turn out to multiple destinations:
@@ -178,6 +181,28 @@ Destinations are **allowlisted**: the owner, joined room(s), and real JIDs curre
 in a room. A reply whose `to:` is missing or points anywhere else is sent to the owner, so
 nothing is silently lost — the agent can't message arbitrary users. In a pure 1:1 account
 (no room) there are no prefixes; replies just go to the owner.
+
+**Answering a specific message (`to: <stanza-id>`).** When several messages arrive before
+any reply, nothing in an outbound reply says which one it answers. So a `to:` line may
+name a **message** instead of a JID, using the `stanza-id:` value from the prompt. pi-msg
+resolves the id to that message's author, sends there, and stamps the outbound stanza with
+a **XEP-0461** `<reply xmlns="urn:xmpp:reply:0" to="<author>" id="<stanza id>"/>` element,
+so the owner's client threads the reply under the message it answers. Rooms are stamped
+too, and only the first chunk of a split reply carries the element. One run can emit
+several replies, each stamped to its own message:
+
+```
+to: 3e2597d4-a470-4cdb-b972-431043bce34f
+On the deploy: done, back in 5.
+to: a8508c81-0e1b-4e48-ae16-61256b837670
+On the creds: staging is stale, I'll rotate them next.
+```
+
+Warning: the id must be complete and known. An unknown or malformed id is a routing
+failure that takes the normal reject path (error room plus a settle-time nudge), not a
+silent fallback — so a wrong id is loud rather than quietly mis-delivered. Two id shapes
+are recognised: the 8-4-4-4-12 hex UUID most clients emit, and the 16 bare hex characters
+pi-msg emits for its own stanzas.
 
 **File transfer.** The agent sends files with the **`send_file`** tool (a structured tool
 call, not in-band text — see [Agent tools](#agent-tools) below): pi-msg uploads the file via

--- a/bridge.go
+++ b/bridge.go
@@ -700,20 +700,23 @@ func (b *Bridge) handleRoom(m InboundMessage) {
 	}
 	switch action {
 	case actionCanonical:
-		// Room reactions enabled → use the room JID and stanza ID so auto-reacts
-		// and send_reaction target the room message. Otherwise clear any stale
-		// 1:1 reaction target.
-		reactTo, reactID := "", ""
+		// The stanza id always travels: it is the handle for "to: <stanza-id>"
+		// reply routing (#54), which works whether or not reactions are on.
+		// Room reactions enabled → also use the room JID as the reaction target,
+		// so auto-reacts and send_reaction hit the room message. Every reaction
+		// path needs BOTH a target jid and an id, so an id with no jid reacts to
+		// nothing.
+		reactTo := ""
 		if b.acct.RoomReactions {
-			reactTo, reactID = m.Room, m.ID
+			reactTo = m.Room
 		}
-		b.handleCanonical(body, m.Room, m.RealJID, reactTo, reactID)
+		b.handleCanonical(body, m.Room, m.RealJID, reactTo, m.ID)
 	case actionCommentary:
-		reactTo, reactID := "", ""
+		reactTo := ""
 		if b.acct.RoomReactions {
-			reactTo, reactID = m.Room, m.ID
+			reactTo = m.Room
 		}
-		b.dispatchCommentary(body, m.Nick, m.Room, m.RealJID, reactTo, reactID)
+		b.dispatchCommentary(body, m.Nick, m.Room, m.RealJID, reactTo, m.ID)
 	case actionAmbient:
 		b.bufferAmbient(m.Nick, m.Body)
 	}
@@ -1183,7 +1186,7 @@ func compactArgs(args Event) string {
 // not on every message; the full spec lives in docs/routing.md. Ownership of
 // the routing protocol belongs to pi-msg, not to any fleet agent config.
 func (b *Bridge) routingContract() string {
-	return fmt.Sprintf("[routing (pi-msg): every reply must begin with a line \"to: <jid>\" naming where it goes. Reply to where a message came from using its \"from:\" jid; DM the sender via their \"sender:\" jid; reach the owner via \"to: %s\". Several \"to:\" lines fan out to different destinations. \"to: %s\" sends nothing (deliberate silence). To wake another agent in a room write \"@name\" inline, or \"@everyone\" for the whole room; a name without @ does not reach them. Full spec: docs/routing.md]", b.acct.Owner, destNoopName)
+	return fmt.Sprintf("[routing (pi-msg): every reply must begin with a line \"to: <jid>\" naming where it goes. Reply to where a message came from using its \"from:\" jid; DM the sender via their \"sender:\" jid; reach the owner via \"to: %s\". Instead of a jid you may write \"to: <stanza-id>\" — a message's \"stanza-id:\" value — which sends to that message's author AND marks your text as a reply to it, so the owner can see which message you answered; use it whenever you answer one of several messages. Copy the id in full: an id that is wrong or unknown fails the send. Several \"to:\" lines fan out to different destinations. \"to: %s\" sends nothing (deliberate silence). To wake another agent in a room write \"@name\" inline, or \"@everyone\" for the whole room; a name without @ does not reach them. Full spec: docs/routing.md]", b.acct.Owner, destNoopName)
 }
 
 // composePrompt assembles the text sent to pi. When the account has room
@@ -1219,8 +1222,10 @@ func (b *Bridge) composePrompt(body string, canonical bool, nick, origin, sender
 			fmt.Fprintf(&sb, "sender: %s\n", sender)
 		}
 	}
-	// Include the stanza ID and target JID so the agent can pass them to
-	// send_reaction as messageId and from-JID respectively.
+	// Include the stanza ID so the agent can name this message later — as
+	// send_reaction's messageId, or as a "to: <stanza-id>" reply route (#54).
+	// react-to is the reaction target jid, and appears only when reactions are
+	// enabled for this channel.
 	if reactID != "" {
 		fmt.Fprintf(&sb, "stanza-id: %s\n", reactID)
 		if reactTo != "" {
@@ -1635,6 +1640,21 @@ func (b *Bridge) deliverReply(text string) bool {
 		b.rejectReply(leading, "this text came before the first \"to:\" line, so it had no destination")
 	}
 	for _, s := range segs {
+		// A stanza-id route (#54) names the message to answer. Resolve it to
+		// that message's author, then continue through the unchanged
+		// classifyDest path — a room message records "room@muc/nick", which
+		// bareJid collapses to the room, and the reply stamp keeps the occupant
+		// jid so the client can attribute it.
+		var reply *replyTarget
+		if s.replyTo != "" {
+			author := b.xmpp.lookupMessage(s.replyTo)
+			if author == "" {
+				b.rejectReply(s.body, fmt.Sprintf("%q is an unknown stanza id", s.replyTo))
+				continue
+			}
+			s.dest = bareJid(author)
+			reply = &replyTarget{author: author, id: s.replyTo}
+		}
 		// "to: noop" — the agent deliberately has nothing to send. Drop the body
 		// without emitting a stanza, and count it as having replied so the
 		// "done (no reply)" nudge doesn't turn room silence into DM noise.
@@ -1659,13 +1679,13 @@ func (b *Bridge) deliverReply(text string) bool {
 		if s.body != "" {
 			var stanzaID string
 			if kind == destRoom {
-				stanzaID = b.xmpp.SendRoomTo(bareJid(s.dest), s.body)
+				stanzaID = b.xmpp.SendRoomReply(bareJid(s.dest), s.body, reply)
 				// A mistyped mention — or a self-tag — is inert: it addresses
 				// nobody and reports nothing, so the sender believes the
 				// handoff landed.
 				b.warnHandleProblems(bareJid(s.dest), s.body)
 			} else {
-				stanzaID = b.xmpp.SendChatTo(s.dest, s.body)
+				stanzaID = b.xmpp.SendChatReply(s.dest, s.body, reply)
 			}
 			// A message routed successfully — any staged correction no longer
 			// applies (#16: nudge only if the FINAL message was malformed, and
@@ -1933,17 +1953,20 @@ func (b *Bridge) bumpRoutingNudge() bool {
 
 func (b *Bridge) resetRoutingNudges() { b.mu.Lock(); b.routingNudges = 0; b.mu.Unlock() }
 
-// replySegment is one routed chunk of an agent reply: a destination jid and the
-// text to send there.
+// replySegment is one routed chunk of an agent reply: a destination and the
+// text to send there. Exactly one of dest and replyTo is set. dest is a jid (or
+// the reserved "noop"). replyTo is the stanza id of the message this segment
+// answers, which deliverReply resolves to a destination through msgHistory.
 type replySegment struct {
-	dest string
-	body string
+	dest    string
+	replyTo string
+	body    string
 }
 
-// splitReplySegments parses an agent reply into "to: <jid>" segments. A line
-// whose first token after "to:" looks like a jid (contains "@") starts a new
-// segment; other lines form the body (that line's remainder plus subsequent
-// lines up to the next "to:"). Text before the first "to:" line is returned as
+// splitReplySegments parses an agent reply into "to: <target>" segments. A line
+// whose first token after "to:" looks like a jid (contains "@"), or like a
+// stanza id, starts a new segment; other lines form the body (that line's
+// remainder plus subsequent lines up to the next "to:"). Text before the first "to:" line is returned as
 // leading (a routing error). This lets one agent output fan out to several
 // destinations.
 func splitReplySegments(text string) (segs []replySegment, leading string) {
@@ -1951,8 +1974,8 @@ func splitReplySegments(text string) (segs []replySegment, leading string) {
 	cur := -1
 	for _, line := range strings.Split(text, "\n") {
 		line = strings.TrimRight(line, "\r")
-		if dest, inline, ok := routeLine(line); ok {
-			segs = append(segs, replySegment{dest: dest, body: inline})
+		if dest, replyTo, inline, ok := routeLine(line); ok {
+			segs = append(segs, replySegment{dest: dest, replyTo: replyTo, body: inline})
 			cur = len(segs) - 1
 			continue
 		}
@@ -1972,34 +1995,68 @@ func splitReplySegments(text string) (segs []replySegment, leading string) {
 	return segs, strings.TrimSpace(strings.Join(leadingLines, "\n"))
 }
 
-// routeLine reports whether line is a "to: <jid>" routing directive, returning
-// the jid and any inline body after it. The jid must contain "@" so ordinary
-// prose beginning with "to:" isn't mistaken for a route.
-func routeLine(line string) (dest, inline string, ok bool) {
+// routeLine reports whether line is a "to: <target>" routing directive,
+// returning what it named and any inline body after it. Three target forms are
+// accepted, and exactly one of dest and replyTo comes back set:
+//
+//	to: noop          → dest = "noop" (send nothing)
+//	to: <jid>         → dest = the jid (contains "@")
+//	to: <stanza-id>   → replyTo = the stanza id (a UUID)
+//
+// A jid must contain "@", and a stanza id must match the UUID shape, so
+// ordinary prose beginning with "to:" is not mistaken for a route.
+func routeLine(line string) (dest, replyTo, inline string, ok bool) {
 	t := strings.TrimLeft(line, " \t")
 	if len(t) < len("to:") || !strings.EqualFold(t[:len("to:")], "to:") {
-		return "", "", false
+		return "", "", "", false
 	}
 	after := strings.TrimLeft(t[len("to:"):], " \t")
-	jid := after
+	target := after
 	if i := strings.IndexAny(after, " \t"); i >= 0 {
-		jid, inline = after[:i], strings.TrimSpace(after[i:])
+		target, inline = after[:i], strings.TrimSpace(after[i:])
 	}
 	// "to: noop" is a real destination meaning "send nothing" (#20). It must be
 	// recognized here rather than falling through to the reject path, or an
 	// agent's attempt at silence would be dumped to the error room AND nudged
 	// for a resend — generating the very turn it was trying to avoid.
-	if strings.EqualFold(jid, destNoopName) {
-		return destNoopName, inline, true
+	if strings.EqualFold(target, destNoopName) {
+		return destNoopName, "", inline, true
 	}
-	if !strings.Contains(jid, "@") {
-		return "", "", false
+	// A stanza id names the message to answer, not a channel (#54). deliverReply
+	// resolves it to that message's author and stamps the outbound reply. The
+	// UUID shape is checked before the "@" test: a UUID has no "@", so this form
+	// is purely additive and no routing line that works today changes meaning.
+	if isStanzaID(target) {
+		return "", target, inline, true
 	}
-	return jid, inline, true
+	if !strings.Contains(target, "@") {
+		return "", "", "", false
+	}
+	return target, "", inline, true
 }
 
 // destNoopName is the reserved "discard this segment" routing destination.
 const destNoopName = "noop"
+
+// stanzaIDRe matches the two stanza-id shapes a routing line can name.
+//
+// The first is the strict 8-4-4-4-12 hex UUID that most clients put on a
+// message, and the shape #54 specifies. The second is pi-msg's own format:
+// newStanzaID emits 16 bare hex characters, so an id the bridge generated would
+// never match a UUID pattern.
+//
+// Both alternatives are checked in full, and a partial id matches neither. That
+// is on purpose: the recorded tradeoff on #54 is that a mistyped id costs the
+// message, so a wrong id is loud rather than quietly mis-delivered. Widening
+// the shape does not weaken that — an id of the right shape that names no
+// recorded message still takes the reject path.
+//
+// A client whose ids match neither shape cannot be answered by id. If that
+// turns up in practice, the fix is to widen this pattern, not to guess.
+var stanzaIDRe = regexp.MustCompile(`^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{16})$`)
+
+// isStanzaID reports whether s has the shape of a stanza id.
+func isStanzaID(s string) bool { return stanzaIDRe.MatchString(s) }
 
 func (b *Bridge) handleModel(arg string) {
 	if arg == "" {
@@ -2409,12 +2466,20 @@ func streamTypingTarget(buf string, xm *XMPPBridge) (target string, decided bool
 	for i := 0; i < end; i++ {
 		l := lines[i]
 		l = strings.TrimRight(l, "\r")
-		dest, _, ok := routeLine(l)
+		dest, replyTo, _, ok := routeLine(l)
 		if !ok {
 			continue
 		}
 		if strings.EqualFold(dest, destNoopName) {
 			return "", true
+		}
+		// A stanza-id route lights the composer only if the id resolves; an
+		// unknown id is a routing failure, and a failure never types.
+		if replyTo != "" {
+			dest = xm.lookupMessage(replyTo)
+			if dest == "" {
+				return "", true
+			}
 		}
 		if xm.classifyDest(dest) == destUser {
 			return bareJid(dest), true

--- a/bridge.go
+++ b/bridge.go
@@ -1882,11 +1882,19 @@ func (b *Bridge) fireUnansweredHint(inbound, delivered int) bool {
 		return false
 	}
 	b.log("notice", fmt.Sprintf("run took %d messages and sent %d replies: asking the agent to check for unanswered ones", inbound, delivered))
-	// Once "to: <stanza-id>" routing lands (issue #54), the destination form
-	// below becomes the stanza id, so each outstanding reply can name the
-	// message it answers.
-	b.rpc.Prompt(fmt.Sprintf("Received %d messages but sent %d replies. If your %d replies addressed all %d messages reply to this with \"to: noop\". If some things outstanding reply to them now using \"to: <jid>\".", inbound, delivered, delivered, inbound), b.steerBehavior())
+	b.rpc.Prompt(unansweredHintText(inbound, delivered), b.steerBehavior())
 	return true
+}
+
+// unansweredHintText builds the hint prompt. Split out from fireUnansweredHint
+// so a test can read the wording without an rpc client.
+//
+// The routing form names the stanza id (#54): this hint fires exactly when
+// several messages are in play, which is the case a bare jid cannot
+// disambiguate. An id both routes the reply and marks it as a reply to the
+// message it answers, so the owner can see which one each reply is for.
+func unansweredHintText(inbound, delivered int) string {
+	return fmt.Sprintf("Received %d messages but sent %d replies. If your %d replies addressed all %d messages reply to this with \"to: noop\". If some things outstanding reply to them now using \"to: <jid|stanza-id>\" — prefer the \"stanza-id:\" value of the message you are answering, so each reply is marked as a reply to it.", inbound, delivered, delivered, inbound)
 }
 
 // bumpHintNudge consumes one unit of the per-turn hint budget.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -3,8 +3,8 @@
 This is the **canonical specification** of how pi-msg routes an agent's replies.
 It is the single source of truth for the routing protocol; the enforcement
 lives in `bridge.go` (`splitReplySegments`, `routeLine`, `deliverReply`,
-`firePendingNudge`) and the on-start description the agent receives lives in
-`Bridge.routingContract()`. This protocol belongs to **pi-msg**, not to any
+`firePendingNudge`) and in `xmpp.go` (`lookupMessage`, `chatStanza`). The
+on-start description the agent receives lives in `Bridge.routingContract()`. This protocol belongs to **pi-msg**, not to any
 individual fleet agent's config.
 
 ## When routing applies
@@ -13,19 +13,30 @@ Routing applies whenever an account has **room/group-chat access**
 (`RoomMode()` is true). Pure `1:1` accounts send their reply to the owner
 verbatim and need no routing line.
 
-## The `to: <jid>` directive
+## The `to: <target>` directive
 
 Every reply from the agent must begin with a line naming its destination:
 
 ```
-to: <jid>
+to: <target>
 body…
 ```
 
+`<target>` is one of three forms:
+
+| Form | Meaning |
+|---|---|
+| `<jid>` | a channel: a joined room, the owner, or a known occupant |
+| `<stanza-id>` | the message to answer; the bridge resolves it to that message's author |
+| `noop` | send nothing (deliberate silence) |
+
 Rules:
 
-- The directive line starts with `to:` (case-insensitive); the target must
-  contain `@` so ordinary prose like "to: be fair" is not mistaken for a route.
+- The directive line starts with `to:` (case-insensitive).
+- A jid target must contain `@`, and a stanza-id target must match one of the
+  two id shapes (`stanzaIDRe`: an 8-4-4-4-12 hex UUID, or 16 bare hex
+  characters), so ordinary prose like "to: be fair" is not mistaken for a
+  route.
 - The body follows on the next line(s).
 - One reply can carry **several** `to:` lines — each starts an independent
   message, fanning out to different destinations.
@@ -33,10 +44,59 @@ Rules:
 
 ### Choosing a destination
 
+- **Answer a specific message** — the prompt's `stanza-id:` value (see below).
 - **Reply where the message came from** — the prompt's `from:` JID.
 - **DM the person who sent it** — the prompt's `sender:` JID (room messages).
 - **Reach the owner** — `to: <owner-jid>` (per-account `owner` in config).
 - **A joined room** → groupchat; the owner or a known occupant → `1:1` chat.
+
+### Answering one message: `to: <stanza-id>`
+
+Every prompt that carries a message includes a `stanza-id:` line. Use that id
+in place of a jid to answer that specific message:
+
+```
+to: 3e2597d4-a470-4cdb-b972-431043bce34f
+A
+
+to: a8508c81-0e1b-4e48-ae16-61256b837670
+B
+```
+
+The bridge does two things with the id:
+
+1. It looks the id up in `msgHistory` (`xmpp.go`) and sends to the author of
+   that message. A room message is recorded as `room@muc/nick`, which collapses
+   to the room, so the reply goes back to the room.
+2. It stamps the outbound message with a **XEP-0461** `<reply/>` element naming
+   the answered message, so a client threads the reply under it:
+
+   ```xml
+   <reply xmlns="urn:xmpp:reply:0" to="<author jid>" id="<stanza id>"/>
+   ```
+
+   Both attributes are mandatory. Only the **first** chunk of a split reply
+   carries the element. Rooms are stamped too.
+
+Destination and attribution travel in one token, so one run can emit several
+replies, each stamped to its own message.
+
+Warning: the id must be complete and known. A malformed or unknown id is a
+routing failure, handled by the normal reject path (error room plus a
+settle-time nudge). It is **not** a silent fallback to the turn destination.
+This is a deliberate tradeoff (#54): a mistyped id costs the message, so a
+wrong id is loud rather than quietly mis-delivered.
+
+`stanzaIDRe` (`bridge.go`) accepts two shapes: the 8-4-4-4-12 hex UUID that
+most clients put on a message, and the 16 bare hex characters `newStanzaID`
+emits for pi-msg's own stanzas. A client whose ids match neither shape cannot be
+answered by id; the fix there is to widen that pattern, not to guess.
+
+Note on history: PRs #50/#51 tried to infer the answered message inside the
+bridge, and #52 reverted them. That attempt failed twice over. Its trigger was
+a race against the `pending1to1` FIFO, and it emitted `urn:xmpp:reply:0` with
+the stanza id in the `to` attribute and no `id` attribute, while calling it
+XEP-0359. The model knows which message it answers, so it names one.
 
 ### Deliberate silence: `to: noop`
 
@@ -60,9 +120,10 @@ Addressed via inline mention, not the `to:` line:
 
 Routing failures are handled by rejection + a bounded corrective:
 
-- Text with no `to:` line, text before the first `to:`, or a non-allowlisted
-  destination is **not dropped silently**: it is forwarded to the write-only
-  `errorRoom` (`routeDropped`) and a corrective is staged.
+- Text with no `to:` line, text before the first `to:`, a non-allowlisted
+  destination, or an **unknown stanza id** is **not dropped silently**: it is
+  forwarded to the write-only `errorRoom` (`routeDropped`) and a corrective is
+  staged.
 - Intermediate/mid-run commentary that fails to route only fills the error
   room and is **not** nudged; the agent is only corrected if the run's
   **FINAL** message was malformed (issue #16).

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -131,6 +131,19 @@ Routing failures are handled by rejection + a bounded corrective:
   prompts the agent to resend with a valid `to:` line — bounded to
   `maxRoutingNudges` per user turn.
 
+## Unanswered-message hint
+
+A message that arrives mid-run is injected as a steer, so the agent can read it
+before it writes the answer to the previous one, and then never write that
+answer. When a run takes in two or more messages and sends fewer replies,
+`fireUnansweredHint` asks the agent once per user turn to check for messages
+that still need an answer.
+
+The hint asks for `to: <jid|stanza-id>` and prefers the stanza id. This is
+exactly the case a bare jid cannot disambiguate: several messages are in play,
+and only the id says which one a reply is for. `to: noop` is the explicit way
+for the agent to say its replies already covered everything.
+
 ## On-start seed
 
 At the start of a **fresh** session (startup with no session to resume, or

--- a/muc_test.go
+++ b/muc_test.go
@@ -219,9 +219,12 @@ func TestRouteLineNoop(t *testing.T) {
 		{"to: nooperator", "", "", false},            // must be exactly "noop"
 	}
 	for _, c := range cases {
-		dest, inline, ok := routeLine(c.in)
+		dest, replyTo, inline, ok := routeLine(c.in)
 		if ok != c.ok || dest != c.dest || inline != c.inline {
 			t.Errorf("routeLine(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, dest, inline, ok, c.dest, c.inline, c.ok)
+		}
+		if replyTo != "" {
+			t.Errorf("routeLine(%q) set replyTo = %q, want empty", c.in, replyTo)
 		}
 	}
 }

--- a/reply_test.go
+++ b/reply_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"encoding/xml"
+	"strings"
+	"testing"
+
+	"mellium.im/xmpp/jid"
+	"mellium.im/xmpp/stanza"
+)
+
+// A well-formed stanza id is a third routing target form, alongside a jid and
+// "noop" (#54). It must not collide with either, and it must not swallow prose.
+func TestRouteLineStanzaID(t *testing.T) {
+	const id = "3e2597d4-a470-4cdb-b972-431043bce34f"
+	cases := []struct {
+		in      string
+		dest    string
+		replyTo string
+		inline  string
+		ok      bool
+	}{
+		// The new form.
+		{"to: " + id, "", id, "", true},
+		{"  to: " + id + " here you go", "", id, "here you go", true},
+		{"to: 3E2597D4-A470-4CDB-B972-431043BCE34F", "", "3E2597D4-A470-4CDB-B972-431043BCE34F", "", true},
+		// pi-msg's own newStanzaID format: 16 bare hex characters.
+		{"to: 3e2597d4a4704cdb", "", "3e2597d4a4704cdb", "", true},
+		// Rejected shapes: a full id is required, so a wrong id is loud.
+		{"to: 3e2597d4-a470-4cdb-b972-431043bce34", "", "", "", false},   // one hex digit short
+		{"to: 3e2597d4-a470-4cdb-b972-431043bce34fa", "", "", "", false}, // one too many
+		{"to: 3e2597d4a4704cd", "", "", "", false},                       // 15 bare hex, one short
+		{"to: 3e2597d4a4704cdbb", "", "", "", false},                     // 17 bare hex, one too many
+		{"to: 3e2597d4-a470-4cdb-b972-431043bce34g", "", "", "", false},  // non-hex digit
+		{"to: whom it may concern", "", "", "", false},                   // prose
+		// Regression: the two existing forms are untouched.
+		{"to: zach@x.com", "zach@x.com", "", "", true},
+		{"to: zach@x.com hello", "zach@x.com", "", "hello", true},
+		{"to: noop", "noop", "", "", true},
+	}
+	for _, c := range cases {
+		dest, replyTo, inline, ok := routeLine(c.in)
+		if ok != c.ok || dest != c.dest || replyTo != c.replyTo || inline != c.inline {
+			t.Errorf("routeLine(%q) = (%q,%q,%q,%v), want (%q,%q,%q,%v)",
+				c.in, dest, replyTo, inline, ok, c.dest, c.replyTo, c.inline, c.ok)
+		}
+	}
+}
+
+// One run may answer several messages, each stamped to its own — the shape the
+// reverted lastReplyTo FIFO (#50/#51) structurally could not express.
+func TestSplitReplySegmentsPerMessageRoutes(t *testing.T) {
+	const a = "3e2597d4-a470-4cdb-b972-431043bce34f"
+	const bID = "a8508c81-0e1b-4e48-ae16-61256b837670"
+	segs, leading := splitReplySegments("to: " + a + "\nA\n\nto: " + bID + "\nB")
+	if leading != "" {
+		t.Fatalf("leading = %q, want empty", leading)
+	}
+	if len(segs) != 2 {
+		t.Fatalf("got %d segments, want 2", len(segs))
+	}
+	if segs[0].replyTo != a || segs[0].body != "A" || segs[0].dest != "" {
+		t.Errorf("segment 0 = %+v", segs[0])
+	}
+	if segs[1].replyTo != bID || segs[1].body != "B" || segs[1].dest != "" {
+		t.Errorf("segment 1 = %+v", segs[1])
+	}
+}
+
+// stagedNudgeReason reads the reason of the staged routing correction, or ""
+// when nothing was rejected.
+func stagedNudgeReason(b *Bridge) string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.pendingNudge == nil {
+		return ""
+	}
+	return b.pendingNudge.reason
+}
+
+// deliverReply must resolve a stanza id to the author of that message. The
+// bridge is offline in tests, so nothing is delivered either way; what is under
+// test is whether the segment reaches the send path or the reject path.
+func TestDeliverReplyResolvesStanzaID(t *testing.T) {
+	acct := ResolvedAccount{Rooms: []string{"team@muc.x"}, ErrorRoom: "errors@muc.x", Owner: "zach@x"}
+	const ownerMsg = "3e2597d4-a470-4cdb-b972-431043bce34f"
+	const roomMsg = "a8508c81-0e1b-4e48-ae16-61256b837670"
+	const unknown = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+	// A known 1:1 id resolves to the owner and is not rejected.
+	b := newTestBridge(acct)
+	b.xmpp.recordMessage(ownerMsg, "zach@x/phone")
+	b.deliverReply("to: " + ownerMsg + "\n\nanswering that one")
+	if r := stagedNudgeReason(b); r != "" {
+		t.Errorf("a known 1:1 stanza id was rejected: %s", r)
+	}
+
+	// A room message records "room@muc/nick"; the existing bareJid path must
+	// collapse that to the room, which classifies as a room destination.
+	b = newTestBridge(acct)
+	b.xmpp.recordMessage(roomMsg, "team@muc.x/alice")
+	b.deliverReply("to: " + roomMsg + "\n\nanswering alice")
+	if r := stagedNudgeReason(b); r != "" {
+		t.Errorf("a known room stanza id was rejected: %s", r)
+	}
+
+	// An unknown id is a routing failure, not a silent fallback.
+	b = newTestBridge(acct)
+	if b.deliverReply("to: " + unknown + "\n\nlost") {
+		t.Error("an unknown stanza id must not count as delivered")
+	}
+	r := stagedNudgeReason(b)
+	if !strings.Contains(r, "unknown stanza id") {
+		t.Errorf("reject reason = %q, want it to name an unknown stanza id", r)
+	}
+
+	// An id whose author is not allowlisted still takes the reject path.
+	b = newTestBridge(acct)
+	b.xmpp.recordMessage(ownerMsg, "stranger@elsewhere/x")
+	b.deliverReply("to: " + ownerMsg + "\n\nhello stranger")
+	if r := stagedNudgeReason(b); !strings.Contains(r, "not an allowed destination") {
+		t.Errorf("reject reason = %q, want a blocked-destination reason", r)
+	}
+}
+
+// The reverted attempt (#50/#51) put the stanza id in `to` and emitted no `id`
+// at all, so no client threaded it. XEP-0461 needs both attributes.
+func TestReplyStanzaGoldenXML(t *testing.T) {
+	to := jid.MustParse("team@muc.x")
+	msg := chatStanza("out-1", to, stanza.GroupChatMessage, "answering alice",
+		&replyTarget{author: "team@muc.x/alice", id: "a8508c81-0e1b-4e48-ae16-61256b837670"})
+	out, err := xml.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(out)
+	for _, want := range []string{
+		`<reply xmlns="urn:xmpp:reply:0"`,
+		`to="team@muc.x/alice"`,
+		`id="a8508c81-0e1b-4e48-ae16-61256b837670"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("stanza %s\nis missing %s", got, want)
+		}
+	}
+
+	// No reply target: no element. Nothing about an ordinary send changes.
+	plain, err := xml.Marshal(chatStanza("out-2", to, stanza.GroupChatMessage, "hi", nil))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(plain), "reply") {
+		t.Errorf("unstamped stanza carries a reply element: %s", plain)
+	}
+
+	// A half-filled target emits nothing: one attribute alone threads nowhere.
+	for _, half := range []*replyTarget{{author: "team@muc.x/alice"}, {id: "abc"}} {
+		out, err := xml.Marshal(chatStanza("out-3", to, stanza.GroupChatMessage, "hi", half))
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if strings.Contains(string(out), "reply") {
+			t.Errorf("half-filled target %+v emitted an element: %s", half, out)
+		}
+	}
+}
+
+// A long reply is split across stanzas. Only the first chunk carries the stamp:
+// a client threads on the first stanza, and a stamp on every chunk makes each
+// chunk a separate reply to the same parent.
+func TestReplyStampFirstChunkOnly(t *testing.T) {
+	rt := &replyTarget{author: "zach@x/phone", id: "3e2597d4-a470-4cdb-b972-431043bce34f"}
+	if got := replyForChunk(0, rt); got != rt {
+		t.Errorf("chunk 0 stamp = %+v, want the reply target", got)
+	}
+	for _, i := range []int{1, 2, 7} {
+		if got := replyForChunk(i, rt); got != nil {
+			t.Errorf("chunk %d stamp = %+v, want none", i, got)
+		}
+	}
+}
+
+// The typing indicator reads the routing line before the reply is delivered, so
+// it must resolve a stanza id the same way deliverReply does.
+func TestStreamTypingTargetStanzaID(t *testing.T) {
+	acct := ResolvedAccount{Rooms: []string{"team@muc.x"}, Owner: "zach@x"}
+	x := NewXMPPBridge(acct, func(InboundMessage) {}, func(string, string) {})
+	const ownerMsg = "3e2597d4-a470-4cdb-b972-431043bce34f"
+	const roomMsg = "a8508c81-0e1b-4e48-ae16-61256b837670"
+	x.recordMessage(ownerMsg, "zach@x/phone")
+	x.recordMessage(roomMsg, "team@muc.x/alice")
+
+	// A 1:1 message resolves to the owner, so the composer lights up.
+	target, decided := streamTypingTarget("to: "+ownerMsg+"\n", x)
+	if !decided || target != "zach@x" {
+		t.Errorf("owner id = (%q,%v), want (\"zach@x\",true)", target, decided)
+	}
+	// A room message is not a 1:1 chat, so the composer stays dark.
+	target, decided = streamTypingTarget("to: "+roomMsg+"\n", x)
+	if !decided || target != "" {
+		t.Errorf("room id = (%q,%v), want (\"\",true)", target, decided)
+	}
+	// An unknown id is a routing failure, and a failure never types.
+	target, decided = streamTypingTarget("to: ffffffff-ffff-ffff-ffff-ffffffffffff\n", x)
+	if !decided || target != "" {
+		t.Errorf("unknown id = (%q,%v), want (\"\",true)", target, decided)
+	}
+}
+
+// The stanza id is the handle for reply routing, so it must reach the agent in
+// every room turn — not only when XEP-0444 reactions happen to be enabled.
+func TestStanzaIDSurfacedWithoutRoomReactions(t *testing.T) {
+	const id = "3e2597d4-a470-4cdb-b972-431043bce34f"
+	acct := ResolvedAccount{Rooms: []string{"team@muc.x"}, Owner: "zach@x", RoomTrigger: "pi"}
+	b := newTestBridge(acct) // RoomReactions is off
+	prompt := b.composePrompt("do it", true, "", "team@muc.x", "zach@x", id, "")
+	if !strings.Contains(prompt, "stanza-id: "+id) {
+		t.Errorf("prompt is missing the stanza id:\n%s", prompt)
+	}
+	if strings.Contains(prompt, "react-to:") {
+		t.Errorf("reactions are off, so react-to must not appear:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "to: <stanza-id>") {
+		t.Errorf("the routing contract must document the stanza-id form:\n%s", prompt)
+	}
+}

--- a/reply_test.go
+++ b/reply_test.go
@@ -207,6 +207,24 @@ func TestStreamTypingTargetStanzaID(t *testing.T) {
 	}
 }
 
+// The unanswered-message hint fires exactly when several messages are in play,
+// which is the case a bare jid cannot disambiguate. It must offer the stanza-id
+// form, and keep "to: noop" as the way to say the replies already covered
+// everything.
+func TestUnansweredHintOffersStanzaID(t *testing.T) {
+	got := unansweredHintText(5, 1)
+	for _, want := range []string{
+		"Received 5 messages but sent 1 replies",
+		`"to: <jid|stanza-id>"`,
+		`"stanza-id:"`,
+		`"to: noop"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("hint is missing %s:\n%s", want, got)
+		}
+	}
+}
+
 // The stanza id is the handle for reply routing, so it must reach the agent in
 // every room turn — not only when XEP-0444 reactions happen to be enabled.
 func TestStanzaIDSurfacedWithoutRoomReactions(t *testing.T) {

--- a/xmpp.go
+++ b/xmpp.go
@@ -64,6 +64,17 @@ const (
 // message with emoji (e.g. 👀 picked up, ✅ done, ⛔ aborted).
 const reactionsNS = "urn:xmpp:reactions:0"
 
+// replyNS is XEP-0461 Message Replies. An outbound message stamped with this
+// element names the message it answers, so a client threads it under that
+// message instead of showing it as a fresh line.
+//
+// Note the history. An earlier attempt (PRs #50/#51, reverted in #52) emitted
+// this namespace with a `to` attribute that held the *stanza id*, and no `id`
+// attribute at all, and called it XEP-0359. XEP-0461 wants `to` = the author of
+// the answered message, and `id` = that message's stanza id. Both attributes
+// are mandatory. One of them alone threads nowhere.
+const replyNS = "urn:xmpp:reply:0"
+
 // discoInfoNS is XEP-0030 service discovery: the bridge answers disco#info
 // queries so contacts can resolve its XEP-0115 capabilities hash.
 const discoInfoNS = "http://jabber.org/protocol/disco#info"
@@ -98,6 +109,7 @@ var discoFeatures = []string{
 	"urn:xmpp:ping",
 	"urn:xmpp:reactions:0",
 	"urn:xmpp:receipts",
+	replyNS,
 	"vcard-temp",
 	"vcard-temp:x:update",
 }
@@ -802,6 +814,8 @@ type incomingMsg struct {
 	markable    bool      // carried a XEP-0333 <markable/> (chat marker)
 	reactions   []string  // XEP-0444 reactions: the emoji set, if this is a reaction
 	reactionFor string    // XEP-0444 reactions id: stanza id of the message being reacted to
+	replyToID   string    // XEP-0461 <reply id>: stanza id of the message this one answers
+	replyToJID  string    // XEP-0461 <reply to>: author of the message this one answers
 }
 
 // handle is the mellium read-loop callback for one inbound stanza.
@@ -821,6 +835,15 @@ func (b *XMPPBridge) handle(t xmlstream.TokenReadEncoder, start *xml.StartElemen
 		if re, ok := element(toks, reactionsNS, "reactions"); ok {
 			m.reactionFor = attr(re.Attr, "id")
 			m.reactions = reactionEmojis(toks)
+		}
+		// XEP-0461: log what a real client puts on the wire. The reverted
+		// attempt (#50/#51) shipped a malformed <reply/> twice because nobody
+		// read one, so record every inbound stamp at notice level. This is the
+		// live confirmation of the attribute names and the namespace.
+		if re, ok := element(toks, replyNS, "reply"); ok {
+			m.replyToID = attr(re.Attr, "id")
+			m.replyToJID = attr(re.Attr, "to")
+			b.log("notice", fmt.Sprintf("inbound XEP-0461 reply stamp from %s: to=%q id=%q", m.from, m.replyToJID, m.replyToID))
 		}
 		if d, ok := element(toks, "urn:xmpp:delay", "delay"); ok {
 			m.delay = true
@@ -1148,13 +1171,21 @@ func (b *XMPPBridge) Send(text string) string { return b.SendChatTo(b.acct.Owner
 // SendChatTo posts a 1:1 chat message to an arbitrary JID, splitting long text.
 // Returns the stanza ID of the last chunk sent, or "" if nothing was sent.
 func (b *XMPPBridge) SendChatTo(to, text string) string {
+	return b.SendChatReply(to, text, nil)
+}
+
+// SendChatReply is SendChatTo with an optional XEP-0461 reply stamp. Only the
+// first chunk of a split message carries the stamp. A client threads on the
+// first stanza, and a repeat of the element on every chunk makes each chunk a
+// separate reply to the same parent.
+func (b *XMPPBridge) SendChatReply(to, text string, reply *replyTarget) string {
 	if b.currentSession() == nil {
 		b.log("warning", "send skipped: not online")
 		return ""
 	}
 	var lastID string
-	for _, part := range chunk(text, maxBody) {
-		id, err := b.encodeChat(to, part, stanza.ChatMessage)
+	for i, part := range chunk(text, maxBody) {
+		id, err := b.encodeChat(to, part, stanza.ChatMessage, replyForChunk(i, reply))
 		if err != nil {
 			b.log("error", "send failed: "+err.Error())
 			break
@@ -1304,7 +1335,57 @@ func (b *XMPPBridge) currentSession() *xmpp.Session {
 
 // --- stanza encoders ---
 
-func (b *XMPPBridge) encodeChat(to, body string, typ stanza.MessageType) (string, error) {
+// replyTarget names the message an outbound message answers (XEP-0461).
+// author is the JID recorded for that message: an occupant JID
+// (room@muc/nick) for a room message, the sender's JID for a 1:1. id is that
+// message's stanza id.
+type replyTarget struct {
+	author string
+	id     string
+}
+
+// replyElem is the XEP-0461 <reply/> child. Both attributes are mandatory.
+type replyElem struct {
+	XMLName xml.Name `xml:"urn:xmpp:reply:0 reply"`
+	To      string   `xml:"to,attr"`
+	ID      string   `xml:"id,attr"`
+}
+
+// chatMessage is one outbound message stanza as it goes on the wire.
+type chatMessage struct {
+	stanza.Message
+	Body  string     `xml:"body"`
+	Reply *replyElem `xml:"reply,omitempty"`
+}
+
+// chatStanza builds one outbound message stanza. reply, when it names both an
+// author and an id, adds the XEP-0461 <reply/> child. A half-filled reply adds
+// nothing: one attribute alone threads nowhere, and an element with a missing
+// attribute is worse than no element.
+func chatStanza(id string, to jid.JID, typ stanza.MessageType, body string, reply *replyTarget) chatMessage {
+	msg := chatMessage{
+		Message: stanza.Message{ID: id, To: to, Type: typ},
+		Body:    body,
+	}
+	if reply != nil && reply.author != "" && reply.id != "" {
+		msg.Reply = &replyElem{To: reply.author, ID: reply.id}
+	}
+	return msg
+}
+
+// replyForChunk returns the reply stamp for chunk i of a split message: the
+// first chunk only. A client threads on the first stanza, so a stamp repeated
+// on every chunk makes each chunk a separate reply to the same parent.
+func replyForChunk(i int, reply *replyTarget) *replyTarget {
+	if i == 0 {
+		return reply
+	}
+	return nil
+}
+
+// encodeChat sends one message stanza. A non-nil reply adds the XEP-0461
+// <reply/> child that names the message this one answers.
+func (b *XMPPBridge) encodeChat(to, body string, typ stanza.MessageType, reply *replyTarget) (string, error) {
 	session := b.currentSession()
 	if session == nil {
 		return "", fmt.Errorf("not online")
@@ -1314,13 +1395,7 @@ func (b *XMPPBridge) encodeChat(to, body string, typ stanza.MessageType) (string
 		return "", fmt.Errorf("invalid recipient %q: %w", to, err)
 	}
 	id := newStanzaID()
-	msg := struct {
-		stanza.Message
-		Body string `xml:"body"`
-	}{
-		Message: stanza.Message{ID: id, To: toJID, Type: typ},
-		Body:    body,
-	}
+	msg := chatStanza(id, toJID, typ, body, reply)
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 	b.recordMessage(id, to)
@@ -1714,13 +1789,20 @@ func (b *XMPPBridge) publishAvatar() error {
 // SendRoomTo posts a groupchat message to a room JID, splitting long text.
 // Returns the stanza ID of the last chunk sent, or "" if nothing was sent.
 func (b *XMPPBridge) SendRoomTo(room, text string) string {
+	return b.SendRoomReply(room, text, nil)
+}
+
+// SendRoomReply is SendRoomTo with an optional XEP-0461 reply stamp, carried on
+// the first chunk only. Rooms are in scope for the stamp because the agent
+// names the answered message. The bridge never infers one.
+func (b *XMPPBridge) SendRoomReply(room, text string, reply *replyTarget) string {
 	if b.currentSession() == nil {
 		b.log("warning", "room send skipped: not online")
 		return ""
 	}
 	var lastID string
-	for _, part := range chunk(text, maxBody) {
-		id, err := b.encodeChat(room, part, stanza.GroupChatMessage)
+	for i, part := range chunk(text, maxBody) {
+		id, err := b.encodeChat(room, part, stanza.GroupChatMessage, replyForChunk(i, reply))
 		if err != nil {
 			b.log("error", "room send failed: "+err.Error())
 			break


### PR DESCRIPTION
Closes #54.

A routing line may now name a message instead of a JID. The bridge resolves the
stanza id to that message's author, sends there, and stamps the outbound stanza
with a XEP-0461 `<reply/>` element:

```
to: 3e2597d4-a470-4cdb-b972-431043bce34f
A

to: a8508c81-0e1b-4e48-ae16-61256b837670
B
```

Destination and attribution travel in one token, so one run can emit several
replies, each stamped to its own message — the shape the reverted `lastReplyTo`
FIFO could not express.

## What changed

| File | Change |
|---|---|
| `bridge.go` | `routeLine` gains a third target form and a `replyTo` field on `replySegment`; `deliverReply` resolves it; `streamTypingTarget` resolves it too; the routing contract and the unanswered-message hint document it |
| `xmpp.go` | `chatStanza` emits the `<reply/>` element; `SendChatReply` / `SendRoomReply` pass a target through; inbound stamps are parsed and logged; `urn:xmpp:reply:0` is advertised in disco#info |
| `docs/routing.md`, `README.md` | the new form, the failure mode, the wire format, and the hint's routing form |
| `reply_test.go` | the tests listed in the issue, plus regressions |

`routeLine` checks the id shape after the `noop` check and before the `@` test.
A stanza id has no `@`, so the form is purely additive and no routing line that
works today changes meaning.

`deliverReply` resolves the id, sets `dest` to the author's bare JID, and
continues through the unchanged `classifyDest` path. A room message records
`room@muc/nick`, which `bareJid` collapses to the room. An unknown id takes the
existing reject path with reason `"…" is an unknown stanza id`.

## The wire format

```xml
<reply xmlns="urn:xmpp:reply:0" to="<author jid>" id="<stanza id>"/>
```

Both attributes. The reverted work (#50/#51) put the stanza id in `to`, omitted
`id`, and called it XEP-0359, so no client would have threaded it even had the
trigger fired. Only the first chunk of a split reply carries the element; a
client threads on the first stanza, and a stamp on every chunk makes each chunk
a separate reply to the same parent. Rooms are stamped too.

`to` is the JID recorded for the answered message, verbatim: the occupant JID
(`room@muc/nick`) for a room message. The issue said "author bare JID", but a
room message's bare JID is the room, not the author, and XEP-0461's own example
uses a full JID. The recorded JID identifies the author in both modes.

## The unanswered-message hint (second commit)

`fireUnansweredHint` (from #55) already carried a note that its destination form
should become the stanza id once this landed. It now asks for
`to: <jid|stanza-id>` and prefers the id. That hint fires exactly when a run
took in several messages and answered fewer — the one case a bare JID cannot
disambiguate. `to: noop` stays the explicit way to say the replies already
covered everything. The wording moved into `unansweredHintText` so a test can
read it without an rpc client.

## Two things worth your eye

**1. The live-stanza check could not run here.** The issue asks for one real
inbound reply stanza to be read before trusting the element. This environment
has no live client and the repo had no raw-stanza logging, so I could not do
that. Instead the bridge now parses every inbound `<reply/>` and logs it:

```
notice: inbound XEP-0461 reply stamp from zach@…/phone: to="…" id="…"
```

Reply to a pi-msg message from your client after this deploys, and the log
confirms the attribute names and namespace against the real thing.

**2. Two changes I made beyond the five listed steps**, both because the
feature does not work without them:

- **The stanza id was invisible.** `composePrompt` prints `stanza-id:` from
  `reactID`, and `handleRoom` only set `reactID` when `acct.RoomReactions` was
  true. That flag defaults to false, so in a default room account the agent
  never sees the handle the whole feature depends on. The id now travels on
  every room turn; the reaction *target JID* stays gated, and every reaction
  path already requires both a target and an id, so nothing starts reacting.
- **`newStanzaID` does not emit UUIDs.** It emits 16 bare hex characters. A
  strict UUID pattern would have matched no id pi-msg generates for its own
  stanzas. `stanzaIDRe` accepts both shapes. Widening does not weaken the
  tradeoff: an id of the right shape naming no recorded message still rejects
  loudly. A client whose ids match neither shape cannot be answered by id —
  the log from item 1 will show whether yours qualifies.

## Verification

`gofmt`, `go build`, `go vet`, `go test` all clean, rebased on `main` at
8c6ed5b. `go test -race` reports the same pre-existing races as `main`
(confirmed by stashing and re-running `TestToolRelayCarriesReason` on the
baseline); nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012E5onR6TPhL3kcZRTZp2Js
