### PR TITLE
fix: hold 'done (no reply)' banner when the routing nudge fires

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -388,8 +388,11 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		// The routing reminder decision happens here (issue #16): mid-run
 		// malformed commentary drops silently, and the agent is only nudged if
 		// the run's FINAL message was malformed (pending nudge set AND nothing
-		// successfully delivered after it). Not before.
-		b.firePendingNudge()
+		// successfully delivered after it). Not before. A launched nudge is
+		// itself a pending reply, so it holds the "done (no reply)" banner: the
+		// resend lands moments later, and showing the banner first would read
+		// as "agent: done, no reply" immediately followed by the resend.
+		nudged := b.firePendingNudge()
 		// A run that ended on a tool call never wrote its answer: the tool
 		// result came back and no assistant text followed it. Ask for the reply
 		// once rather than letting the work vanish. A deliberate silence uses
@@ -412,9 +415,11 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		// The reply text + typing/presence already signal "done". Only nudge if
 		// the run produced no message, so silence isn't mistaken for a hang.
 		// A run woken purely by a reaction ack (reactionAckRun) is allowed to
-		// stay silent after a to:noop without spamming the owner. A recovery
-		// prompt is in flight, so hold the banner: the retry may still answer.
-		if !b.replied() && !b.volunteered && !b.reactionAckRun && !recovering {
+		// stay silent after a to:noop without touching the owner. A recovery
+		// prompt (tail retry or routing nudge) is in flight, so hold the
+		// banner: the retry may still answer, and "done (no reply)" followed
+		// by the resend would read as a contradiction.
+		if !b.replied() && !b.volunteered && !b.reactionAckRun && !recovering && !nudged {
 			b.reply("✅ done (no reply) — your turn")
 		}
 		b.volunteered = false // a resume volunteer turn is a one-shot; never repeats
@@ -1957,12 +1962,13 @@ func (b *Bridge) fireTailRecovery() bool {
 // firePendingNudge sends the staged routing reminder, if the run settled on a
 // malformed final message. Called from agent_settled only; the reminder is a
 // prompt, so it isn't confused for a real user.
-func (b *Bridge) firePendingNudge() {
+func (b *Bridge) firePendingNudge() bool {
 	reason := b.takeStagedNudge()
 	if reason == "" {
-		return
+		return false
 	}
 	b.rpc.Prompt(fmt.Sprintf("Your previous message was NOT delivered to anyone in the chat: %s. Every reply MUST begin with a line \"to: <jid>\" naming the destination (e.g. \"to: %s\" for the owner, or a room/person jid). Resend your message now with a valid \"to:\" line.", reason, b.acct.Owner), b.steerBehavior())
+	return true
 }
 
 // routeDropped sends dropped/unrouteable output to the write-only error room

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -313,6 +313,31 @@ func TestStagedNudgeRespectsBudget(t *testing.T) {
 	}
 }
 
+// TestFirePendingNudgeReportsLaunch pins the banner-suppression contract: a
+// settle that launches the routing nudge holds the "done (no reply)" banner,
+// because the resend arrives moments later. firePendingNudge must report
+// whether it actually launched so the caller can gate on it.
+func TestFirePendingNudgeReportsLaunch(t *testing.T) {
+	b := roomBridge()
+	b.rpc = &RPCClient{} // fire-and-forget send to nowhere; avoids a nil deref
+
+	// Nothing staged → no nudge launches.
+	if b.firePendingNudge() {
+		t.Error("no staged nudge → firePendingNudge must report false")
+	}
+
+	// A staged correction → the nudge fires and is reported.
+	b.stageNudge("dropped body", "no to: line")
+	if !b.firePendingNudge() {
+		t.Error("staged nudge → firePendingNudge must report true")
+	}
+
+	// Consumed on fire → nothing left to launch.
+	if b.firePendingNudge() {
+		t.Error("after firing, no second nudge may launch")
+	}
+}
+
 func TestPrettyDump(t *testing.T) {
 	jsonl := strings.Join([]string{
 		`{"type":"session","timestamp":"2024-12-03T14:00:00.000Z","cwd":"/proj"}`,


### PR DESCRIPTION
## Problem

When an agent reply fails to route (no `to:` line), the bridge drops the text to the write-only error room and stages a routing-reminder prompt which it launches at `agent_settled`. The settle-time banner didn't account for that:

```
agent: ✅ done (no reply) — your turn
agent: here's my response          ← the nudge-driven resend
```

The owner sees "done, no reply" immediately followed by the reply — a contradiction, and the banner was wrong: a reply *was* coming.

## Fix

- `firePendingNudge()` now returns whether it actually launched a nudge prompt
- `agent_settled` holds the banner when it did, alongside the existing tail-recovery (`recovering`) and unanswered-hint holds

If the resend also fails to route, the budget still bounds nudges and the banner eventually fires — nothing is suppressed forever.

## Test

`TestFirePendingNudgeReportsLaunch` pins the launch contract (nothing staged → false; staged → true; consumed on fire → false). Full suite passes.