### PR TITLE
feat: show the run's chat history in the unanswered-message hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sequenceDiagram
 | `/session` | session stats — id, file, message counts, tokens, cost (no LLM turn) |
 | `/name [name]` | show the session display name, or set it |
 | `/think <off\|low\|medium\|high\|…>` | `set_thinking_level` |
-| `/abort` (or `/stop`) | `abort` |
+| `/abort` (or `/stop`) | `clear_queue`, then `abort` — the queue drain stops a steer that landed mid-run from starting a fresh run the instant the aborted one stops. The reply names how many queued messages it dropped. |
 | `/dump` (or `/dump pretty`) | send the session transcript to the owner — raw JSONL, or `pretty` for indented per-record JSON (no LLM turn) |
 | `/export` | render the current session to HTML via pi's `export_html` RPC and **send it as a file over XMPP** (XEP-0363 HTTP Upload) — **deterministic**, no agent turn; the rendered session lands as an inline, downloadable file |
 | `/quit` (or `/exit`) | shut down the bridge and Pi |
@@ -209,6 +209,19 @@ side-effect actions are tools.
 ```bash
 go build -o pi-msg . && ./pi-msg     # from the repo
 ```
+
+### Supported pi version
+
+pi-msg targets **pi 0.84.0 or later**. Two reasons:
+
+- Pi 0.84.0 removed the cumulative `message` field and
+  `assistantMessageEvent.partial` from the `message_update` RPC event. pi-msg
+  drives the typing indicator and the presence label from the deltas alone
+  (`TestStreamDeltaContract` pins this), so it works on both shapes — but no
+  new code may reach for the removed fields.
+- `/abort` uses `clear_queue`, added in pi 0.84.4. On an older pi the command
+  is unknown, so pi-msg logs the failure at `info` and aborts exactly as
+  before, reporting no dropped messages.
 
 ### Nix
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,14 @@ sequenceDiagram
   agent can read the new question before it writes the answer to the previous
   one, and then never write it. When a run takes in more messages than it sends
   replies, the bridge asks it once per turn to check for messages that still
-  need an answer. The hint asks for `to: <jid|stanza-id>` and prefers the
-  stanza id, which is exactly the case a bare JID cannot disambiguate: an id
-  both routes the reply and marks it as a reply to the message it answers. The
-  agent answers them all in that one turn, with several `to:` lines, or replies
-  `to: noop` if it already covered everything. The run that answers a hint is
+  need an answer. The hint carries the run's chat history — every message in and
+  every reply out, in order, each with its stanza id — because the agent cannot
+  see the XMPP traffic and the bare counts leave it guessing which message it
+  missed. The hint asks for `to: <jid|stanza-id>`: an id both routes the reply
+  and marks it as a reply to the message it answers. The agent answers them all
+  in that one turn, with several `to:` lines, or replies `to: noop` if it already
+  covered everything. Each `to:` segment counts as one answer, so a single reply
+  that fans out to three people is not mistaken for one unanswered message. The run that answers a hint is
   never hinted about in turn. `to: noop` counts as an answer, so deliberate
   silence is never flagged.
 - Messages you send are acknowledged with a single **read receipt** — a XEP-0333
@@ -169,7 +172,8 @@ And **every** agent reply must begin with a `to:` line naming its destination:
 - `to: <room jid>` → the group chat (groupchat)
 - `to: <owner or occupant jid>` → that person, 1:1
 - `to: <stanza-id>` → the author of that message, with the reply **stamped** to it
-- `to: noop` → send nothing (deliberate silence)
+- `to: noop` → send nothing (deliberate silence); the only `to:` form a pure
+  1:1 account parses, and it must be the reply's first line
 
 One reply may contain **several `to:` blocks** — each `to:` line starts a new message, so
 the agent can fan a single turn out to multiple destinations:

--- a/bridge.go
+++ b/bridge.go
@@ -82,7 +82,12 @@ type Bridge struct {
 	// Comparing the two counts at settle catches exactly that.
 	runInbound    int
 	runDeliveries int
-	hintNudges    int // unanswered-message hints sent this user turn (bounded)
+	// runLog records the same traffic as the two counters, in arrival order,
+	// so the unanswered-message hint can show the agent what the run actually
+	// received and sent. The counters alone say "3 in, 2 out" and leave the
+	// agent to guess which message went unanswered.
+	runLog     []runLogEntry
+	hintNudges int // unanswered-message hints sent this user turn (bounded)
 	// hintPending marks the run the agent starts in answer to a hint. That run
 	// must never be hinted about in turn: the agent has just been asked to catch
 	// up, so whatever it sends IS the catch-up. Hinting again would ask it to
@@ -404,7 +409,7 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		// judged normally again.
 		if !recovering && !b.takeHintPending() {
 			if n, m, ok := b.unansweredRun(); ok {
-				recovering = b.fireUnansweredHint(n, m)
+				recovering = b.fireUnansweredHint(n, m, b.runLogSnapshot())
 			}
 		}
 		// The counts belong to the run that just ended, whatever we decided.
@@ -458,7 +463,6 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		if b.deliverReply(text) {
 			b.setReplied(true)
 			b.clearToolSinceDelivery()
-			b.countDelivery()
 		}
 	case "extension_error":
 		b.reply("⚠️ extension error: " + orUnknown(ev.Str("error")))
@@ -619,7 +623,7 @@ func (b *Bridge) onInbound(m InboundMessage) {
 	if m.Direct {
 		// Owner 1:1: origin is the owner; no separate sender. The reaction target
 		// is this message (routed to its full from-JID).
-		b.handleCanonical(m.Body, b.acct.Owner, "", m.From, m.ID)
+		b.handleCanonical(m.Body, "", b.acct.Owner, "", m.From, m.ID)
 		return
 	}
 	b.handleRoom(m)
@@ -718,7 +722,7 @@ func (b *Bridge) handleRoom(m InboundMessage) {
 		if b.acct.RoomReactions {
 			reactTo = m.Room
 		}
-		b.handleCanonical(body, m.Room, m.RealJID, reactTo, m.ID)
+		b.handleCanonical(body, m.Nick, m.Room, m.RealJID, reactTo, m.ID)
 	case actionCommentary:
 		reactTo := ""
 		if b.acct.RoomReactions {
@@ -730,11 +734,29 @@ func (b *Bridge) handleRoom(m InboundMessage) {
 	}
 }
 
+// senderName picks the name that identifies a message's sender in the
+// unanswered-message hint's history: the room nick when there is one, else the
+// local part of the sender's jid, else of the jid the message arrived on.
+func senderName(nick, sender, origin string) string {
+	if nick != "" {
+		return nick
+	}
+	if n := localpart(sender); n != "" {
+		return n
+	}
+	if n := localpart(origin); n != "" {
+		return n
+	}
+	return "user"
+}
+
 // handleCanonical handles a trusted (owner / 1:1) message: control commands
 // dispatch directly; anything else becomes a canonical prompt. origin is the
 // jid the message arrived on (owner or room); sender is the individual (room
-// only), both surfaced to the agent for explicit reply routing.
-func (b *Bridge) handleCanonical(text, origin, sender, reactTo, reactID string) {
+// only), both surfaced to the agent for explicit reply routing. nick is the
+// sender's occupant nick in a room, "" in a 1:1 — it only names the sender in
+// the unanswered-message hint's history.
+func (b *Bridge) handleCanonical(text, nick, origin, sender, reactTo, reactID string) {
 	t := strings.TrimSpace(text)
 	if t == "" {
 		return
@@ -746,7 +768,7 @@ func (b *Bridge) handleCanonical(text, origin, sender, reactTo, reactID string) 
 	// and remember where a reply (or tool-driven file) should go by default.
 	b.setLifecycleReactTarget(reactTo, reactID)
 	b.setTurnDest(origin)
-	b.countInbound()
+	b.countInbound(senderName(nick, sender, origin), reactID, t)
 	b.rpc.Prompt(b.composePrompt(t, true, "", origin, sender, reactID, reactTo), b.steerBehavior())
 	b.busyPresence("thinking…")
 }
@@ -761,7 +783,7 @@ func (b *Bridge) dispatchCommentary(body, nick, origin, sender, reactTo, reactID
 	}
 	b.setLifecycleReactTarget(reactTo, reactID)
 	b.setTurnDest(origin)
-	b.countInbound()
+	b.countInbound(senderName(nick, sender, origin), reactID, t)
 	b.rpc.Prompt(b.composePrompt(t, false, nick, origin, sender, reactID, reactTo), b.steerBehavior())
 	b.busyPresence("thinking…")
 }
@@ -1204,7 +1226,7 @@ func compactArgs(args Event) string {
 // not on every message; the full spec lives in docs/routing.md. Ownership of
 // the routing protocol belongs to pi-msg, not to any fleet agent config.
 func (b *Bridge) routingContract() string {
-	return fmt.Sprintf("[routing (pi-msg): every reply must begin with a line \"to: <jid>\" naming where it goes. Reply to where a message came from using its \"from:\" jid; DM the sender via their \"sender:\" jid; reach the owner via \"to: %s\". Instead of a jid you may write \"to: <stanza-id>\" — a message's \"stanza-id:\" value — which sends to that message's author AND marks your text as a reply to it, so the owner can see which message you answered; use it whenever you answer one of several messages. Copy the id in full: an id that is wrong or unknown fails the send. Several \"to:\" lines fan out to different destinations. \"to: %s\" sends nothing (deliberate silence). To wake another agent in a room write \"@name\" inline, or \"@everyone\" for the whole room; a name without @ does not reach them. Full spec: docs/routing.md]", b.acct.Owner, destNoopName)
+	return fmt.Sprintf("[routing (pi-msg): every reply must begin with a line \"to: <jid|stanza-id>\" naming where it goes. Default to the jid form: reply to where a message came from using its \"from:\" jid; DM the sender via their \"sender:\" jid; reach the owner via \"to: %s\". Use the id form, \"to: <stanza-id>\" — a message's \"stanza-id:\" value — only when a bare jid does not show which message you answer: it sends to that message's author AND marks your text as a reply to that exact message, so the owner can see which one you answered. Copy the id in full: an id that is wrong or unknown fails the send. Several \"to:\" lines fan out to different destinations. \"to: %s\" sends nothing (deliberate silence). To wake another agent in a room write \"@name\" inline, or \"@everyone\" for the whole room; a name without @ does not reach them. Full spec: docs/routing.md]", b.acct.Owner, destNoopName)
 }
 
 // composePrompt assembles the text sent to pi. When the account has room
@@ -1634,6 +1656,16 @@ func (b *Bridge) reply(text string) {
 func (b *Bridge) deliverReply(text string) bool {
 	delivered := false
 	if !b.acct.RoomMode() {
+		// A 1:1 account has no routing contract, but "to: noop" still works: it
+		// is the only way the agent can say "I have nothing to send" without the
+		// run looking like a reply that went missing. As in room mode, the body
+		// after it is discarded.
+		if leadingNoop(text) {
+			b.log("notice", "agent chose silence (to: noop)")
+			b.setReplied(true)
+			b.recordDelivery("", "")
+			return true
+		}
 		// Deliberate reactions are the send_reaction tool's job now; a 1:1 reply
 		// is just its text.
 		if strings.TrimSpace(text) != "" {
@@ -1642,6 +1674,7 @@ func (b *Bridge) deliverReply(text string) bool {
 			// send_reaction calls target the agent's own message.
 			if stanzaID != "" {
 				b.setReactTarget(b.acct.Owner, stanzaID)
+				b.recordDelivery(stanzaID, text)
 				delivered = true
 			}
 		}
@@ -1684,6 +1717,7 @@ func (b *Bridge) deliverReply(text string) bool {
 			b.log("notice", "agent chose silence (to: noop)")
 			b.clearPendingNudge()
 			b.setReplied(true)
+			b.recordDelivery("", "")
 			// Deliberate silence IS an answer: it must not look like a run that
 			// died before writing one, or the recovery would argue with it.
 			delivered = true
@@ -1710,6 +1744,7 @@ func (b *Bridge) deliverReply(text string) bool {
 			// "a later message routed fine" discards the staged nudge).
 			if stanzaID != "" {
 				b.clearPendingNudge()
+				b.recordDelivery(stanzaID, s.body)
 				delivered = true
 			}
 			// Update reaction target to the last-segment message so subsequent
@@ -1852,12 +1887,76 @@ func (b *Bridge) resetTailNudges() { b.mu.Lock(); b.tailNudges = 0; b.mu.Unlock(
 // maxHintNudges bounds how many unanswered-message hints we send per user turn.
 const maxHintNudges = 1
 
+// runLogEntry is one line of the current run's chat history: a message that
+// came in, or a reply that went out. The stanza id is the handle the agent
+// needs to answer that exact message ("to: <stanza-id>").
+type runLogEntry struct {
+	who  string // display name: the sender's nick for inbound, our own nick for a reply
+	id   string // stanza id of the message ("" when the send reported none)
+	text string // short excerpt of the body ("" for a deliberate silence)
+	sent bool   // true for the agent's own reply
+}
+
+// line renders the entry for the hint's history block.
+func (e runLogEntry) line() string {
+	id := e.id
+	if id == "" {
+		id = "(no id)"
+	}
+	if e.text == "" {
+		return fmt.Sprintf("%s: %s (deliberate silence, to: noop)", e.who, id)
+	}
+	return fmt.Sprintf("%s: %s %q", e.who, id, e.text)
+}
+
 // countInbound records that a chat message entered the current run. Called for
 // the message that starts a run and for every steer that lands while it runs.
-func (b *Bridge) countInbound() { b.mu.Lock(); b.runInbound++; b.mu.Unlock() }
+// who/id/text describe the message for the hint's history block.
+func (b *Bridge) countInbound(who, id, text string) {
+	b.mu.Lock()
+	b.runInbound++
+	b.runLog = append(b.runLog, runLogEntry{who: who, id: id, text: hintExcerpt(text)})
+	b.mu.Unlock()
+}
 
-// countDelivery records that a reply reached a destination in the current run.
-func (b *Bridge) countDelivery() { b.mu.Lock(); b.runDeliveries++; b.mu.Unlock() }
+// recordDelivery records one answer that reached its destination: a sent
+// stanza, or a "to: noop" (deliberate silence is an answer). It also adds the
+// reply to the run's history, so only deliverReply calls it — nothing else
+// knows the stanza ids.
+//
+// It counts per SEGMENT, not per assistant message. One message can carry
+// several "to:" lines that fan out to several people, and counting that as a
+// single reply made a run that answered every message look unbalanced, which
+// fired the unanswered-message hint for work that was already done.
+func (b *Bridge) recordDelivery(id, text string) {
+	b.mu.Lock()
+	b.runDeliveries++
+	b.runLog = append(b.runLog, runLogEntry{who: b.acct.Nick, id: id, text: hintExcerpt(text), sent: true})
+	b.mu.Unlock()
+}
+
+// runLogSnapshot copies the run's history for the hint.
+func (b *Bridge) runLogSnapshot() []runLogEntry {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]runLogEntry(nil), b.runLog...)
+}
+
+// hintExcerpt shortens a body to its first few words on one line, so the hint's
+// history identifies a message without repeating it in full.
+func hintExcerpt(text string) string {
+	s := strings.Join(strings.Fields(text), " ")
+	const max = 48
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	cut := string(r[:max])
+	if i := strings.LastIndex(cut, " "); i > 0 {
+		cut = cut[:i]
+	}
+	return cut + "…"
+}
 
 // resetRunCounts clears the per-run message/reply tally. Called at settle,
 // AFTER the decision, and on an aborted run.
@@ -1869,6 +1968,7 @@ func (b *Bridge) resetRunCounts() {
 	b.mu.Lock()
 	b.runInbound = 0
 	b.runDeliveries = 0
+	b.runLog = nil
 	b.mu.Unlock()
 }
 
@@ -1895,18 +1995,24 @@ func (b *Bridge) unansweredRun() (inbound, delivered int, ok bool) {
 // The hint is a prompt, not a chat message: it never reaches the owner. The
 // agent answers it with real replies, or with "to: noop" if it already covered
 // everything — so a correctly-handled run costs one cheap turn and no noise.
-func (b *Bridge) fireUnansweredHint(inbound, delivered int) bool {
+func (b *Bridge) fireUnansweredHint(inbound, delivered int, history []runLogEntry) bool {
 	if !b.bumpHintNudge() {
 		return false
 	}
 	b.log("notice", fmt.Sprintf("run took %d messages and sent %d replies: asking the agent to check for unanswered ones", inbound, delivered))
-	b.rpc.Prompt(unansweredHintText(inbound, delivered), b.steerBehavior())
+	b.rpc.Prompt(unansweredHintText(inbound, delivered, history, b.acct.RoomMode()), b.steerBehavior())
 	b.markHintPending()
 	return true
 }
 
 // unansweredHintText builds the hint prompt. Split out from fireUnansweredHint
 // so a test can read the wording without an rpc client.
+//
+// The counts alone ("3 in, 2 out") do not tell the agent WHICH message it
+// missed: it cannot see the XMPP traffic, so it has to reconstruct the run from
+// its own context and gets it wrong. The hint therefore prints the run's chat
+// history — every message in and every reply out, in order, each with its
+// stanza id — and the agent matches its replies against it.
 //
 // The routing form names the stanza id (#54): this hint fires exactly when
 // several messages are in play, which is the case a bare jid cannot
@@ -1916,8 +2022,29 @@ func (b *Bridge) fireUnansweredHint(inbound, delivered int) bool {
 // It also names the multi-destination form: the hint asks for every outstanding
 // reply, and several "to:" lines in one reply fan out, so the agent can clear
 // the whole backlog in the single turn the hint buys it.
-func unansweredHintText(inbound, delivered int) string {
-	return fmt.Sprintf("Received %d messages but sent %d replies. If your %d replies addressed all %d messages reply to this with \"to: noop\". If anything is outstanding reply to them now using \"to: <jid|stanza-id>\" — prefer the \"stanza-id:\" value of the message you are answering, so each reply is marked as a reply to it. Several \"to:\" lines in one reply fan out to different destinations, so you can answer every outstanding message in this one turn.", inbound, delivered, delivered, inbound)
+func unansweredHintText(inbound, delivered int, history []runLogEntry, roomMode bool) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "[pi-msg] You received %d messages but sent %d replies. Make sure that your replies addressed all %d received messages.", inbound, delivered, inbound)
+	if len(history) > 0 {
+		sb.WriteString(" Here is this run's chat history in XMPP, in order, with the stanza id of each message:\n\n")
+		for _, e := range history {
+			sb.WriteString(e.line())
+			sb.WriteString("\n")
+		}
+		sb.WriteString("\n")
+	} else {
+		sb.WriteString(" ")
+	}
+	if roomMode {
+		sb.WriteString("If anything is outstanding reply to it now using \"to: <jid|stanza-id>\" — a stanza id from the history above routes the reply to that message's author AND marks it as a reply to that exact message. Several \"to:\" lines in one reply fan out to different destinations, so you can answer every outstanding message in this one turn. ")
+	} else {
+		// A 1:1 account parses no "to: <destination>" line, so asking for one
+		// would put the literal text in front of the owner. Only "to: noop"
+		// works here (leadingNoop).
+		sb.WriteString("If anything is outstanding answer it now — you can answer every outstanding message in this one reply. ")
+	}
+	sb.WriteString("If your replies covered everything the user wanted already, reply with \"to: noop\" and nothing else.")
+	return sb.String()
 }
 
 // markHintPending records that the next run answers a hint.
@@ -1954,9 +2081,10 @@ func (b *Bridge) fireTailRecovery() bool {
 	}
 	b.log("notice", "run ended on a tool call with no reply: asking the agent to write it")
 	// A pure 1:1 account has no routing contract, so don't ask it for a "to:"
-	// line it must not write.
+	// line it must not write. "to: noop" is the exception: it works in both
+	// modes (leadingNoop), and it is how the agent declines to say anything.
 	const base = "Your last run ended after a tool call without writing any reply, so nothing was delivered to the chat. The tool result is above. Write the reply now."
-	prompt := base
+	prompt := fmt.Sprintf("%s If you truly have nothing to say, reply with \"to: noop\" and nothing else.", base)
 	if b.acct.RoomMode() {
 		prompt = fmt.Sprintf("%s Begin it with a \"to: <jid>\" line (e.g. \"to: %s\" for the owner). If you truly have nothing to say, reply with \"to: noop\".", base, b.acct.Owner)
 	}
@@ -2077,6 +2205,20 @@ func routeLine(line string) (dest, replyTo, inline string, ok bool) {
 		return "", "", "", false
 	}
 	return target, "", inline, true
+}
+
+// leadingNoop reports whether text's first non-empty line is a "to: noop"
+// routing line. Used in 1:1 mode, which parses no other routing form: any other
+// text is an ordinary reply and is sent as written.
+func leadingNoop(text string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		dest, _, _, ok := routeLine(strings.TrimRight(line, "\r"))
+		return ok && strings.EqualFold(dest, destNoopName)
+	}
+	return false
 }
 
 // destNoopName is the reserved "discard this segment" routing destination.
@@ -2897,7 +3039,7 @@ func (b *Bridge) replayInbound() {
 		b.reply(fmt.Sprintf("Back online, catching up on %d messages", len(msgs)))
 		for _, m := range msgs {
 			if m.Direct {
-				b.handleCanonical(m.Body, b.acct.Owner, "", m.From, m.ID)
+				b.handleCanonical(m.Body, "", b.acct.Owner, "", m.From, m.ID)
 			} else {
 				b.handleRoom(m)
 			}

--- a/bridge.go
+++ b/bridge.go
@@ -744,10 +744,20 @@ func (b *Bridge) handleCommand(t string) bool {
 	case "session":
 		b.handleSession()
 	case "abort", "stop":
+		// Drain the queue BEFORE aborting. `abort` alone leaves queued steers
+		// and follow-ups in the session, so pi starts a fresh run the moment
+		// the aborted one stops — the opposite of what "⛔ aborted" promises.
+		dropped := b.clearQueue()
 		b.rpc.Abort()
 		b.settleLocally()
 		b.lifecycleReact("⛔") // aborted
-		b.reply("⛔ aborted")
+		msg := "⛔ aborted"
+		if dropped == 1 {
+			msg += " (1 queued message dropped)"
+		} else if dropped > 1 {
+			msg += fmt.Sprintf(" (%d queued messages dropped)", dropped)
+		}
+		b.reply(msg)
 	case "quit", "exit":
 		b.shutdown("requested over chat")
 	case "dump":
@@ -2223,6 +2233,25 @@ func (b *Bridge) stopTyping() {
 		b.xmpp.ChatStateTo("active", b.typingTo)
 		b.typingTo = ""
 	}
+}
+
+// clearQueue drops pi's queued steering and follow-up messages and returns how
+// many it dropped. Requires pi >= 0.84.4 (`clear_queue`). On an older pi the
+// command is unknown, so the request fails; that is logged at info and reported
+// as 0 dropped, leaving the caller's abort to proceed exactly as before.
+func (b *Bridge) clearQueue() int {
+	res, err := b.rpc.ClearQueue(b.ctx)
+	if err != nil {
+		b.log("info", "clear_queue failed: "+err.Error())
+		return 0
+	}
+	if !res.success() {
+		// Expected against pi < 0.84.4 — not a warning.
+		b.log("info", "clear_queue unavailable: "+res.errText())
+		return 0
+	}
+	data := res.Obj("data")
+	return len(data.Arr("steering")) + len(data.Arr("followUp"))
 }
 
 // settleLocally resets run-scoped UI (streaming flag, typing indicator,

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"io"
@@ -503,16 +504,16 @@ func TestLoadAwayActivities(t *testing.T) {
 // learns *why* something failed (issue #34: e.g. an upload rejected by the
 // server as too large never reached the agent).
 func TestToolRelayCarriesReason(t *testing.T) {
-	var buf bytes.Buffer
+	stdin := &nopClose{buf: &bytes.Buffer{}}
 	b := roomBridge()
-	b.rpc = &RPCClient{stdin: &nopClose{buf: &buf}, mu: sync.Mutex{}}
+	b.rpc = &RPCClient{stdin: stdin, mu: sync.Mutex{}}
 	b.xmpp = &XMPPBridge{ownerBare: "zach@x.com"} // owner allowlisted; SendFile fails fast ("not online")
 
 	readLine := func(t *testing.T) map[string]any {
 		t.Helper()
 		deadline := time.Now().Add(2 * time.Second)
 		for {
-			if line, err := buf.ReadString('\n'); err == nil {
+			if line, err := stdin.readString('\n'); err == nil {
 				var resp map[string]any
 				if err := json.Unmarshal([]byte(line), &resp); err != nil {
 					t.Fatalf("bad relay response line %q: %v", line, err)
@@ -520,7 +521,7 @@ func TestToolRelayCarriesReason(t *testing.T) {
 				return resp
 			}
 			if time.Now().After(deadline) {
-				t.Fatalf("no relay response within 2s (buf=%q)", buf.String())
+				t.Fatalf("no relay response within 2s (buf=%q)", stdin.contents())
 			}
 			time.Sleep(5 * time.Millisecond)
 		}
@@ -557,9 +558,9 @@ func TestToolRelayCarriesReason(t *testing.T) {
 // TestToolRelaySuccessOk: a successful relay answers "ok", which the extension
 // maps to a clean tool result (as opposed to a generic failure).
 func TestToolRelaySuccessOk(t *testing.T) {
-	var buf bytes.Buffer
+	stdin := &nopClose{buf: &bytes.Buffer{}}
 	b := roomBridge()
-	b.rpc = &RPCClient{stdin: &nopClose{buf: &buf}, mu: sync.Mutex{}}
+	b.rpc = &RPCClient{stdin: stdin, mu: sync.Mutex{}}
 	b.xmpp = &XMPPBridge{ownerBare: "zach@x.com"}
 
 	// The react path is synchronous and doesn't need a live session: a missing
@@ -570,12 +571,12 @@ func TestToolRelaySuccessOk(t *testing.T) {
 	deadline := time.Now().Add(2 * time.Second)
 	var line string
 	for {
-		if l, err := buf.ReadString('\n'); err == nil {
+		if l, err := stdin.readString('\n'); err == nil {
 			line = l
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("no relay response within 2s (buf=%q)", buf.String())
+			t.Fatalf("no relay response within 2s (buf=%q)", stdin.contents())
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
@@ -585,10 +586,36 @@ func TestToolRelaySuccessOk(t *testing.T) {
 }
 
 // nopClose adapts a bytes.Buffer to io.WriteCloser for RPCClient.stdin.
-type nopClose struct{ buf *bytes.Buffer }
+//
+// The mutex is not decoration: the relay handler writes from its own goroutine
+// while the test reads the same buffer, so both sides must go through the lock.
+// Read the buffer with readString/contents, never through the wrapped buffer.
+type nopClose struct {
+	mu  sync.Mutex
+	buf *bytes.Buffer
+}
 
-func (n *nopClose) Write(p []byte) (int, error) { return n.buf.Write(p) }
-func (n *nopClose) Close() error                { return nil }
+func (n *nopClose) Write(p []byte) (int, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.buf.Write(p)
+}
+
+func (n *nopClose) Close() error { return nil }
+
+// readString consumes one delimited line, mirroring bytes.Buffer.ReadString.
+func (n *nopClose) readString(delim byte) (string, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.buf.ReadString(delim)
+}
+
+// contents returns everything still buffered, for failure messages.
+func (n *nopClose) contents() string {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.buf.String()
+}
 
 func TestOpenRouterCreditsParse(t *testing.T) {
 	// Build a throwaway HTTP server to avoid hitting the real endpoint.
@@ -609,5 +636,114 @@ func TestOpenRouterCreditsParse(t *testing.T) {
 	}
 	if total != 85 || used != 81.11 {
 		t.Fatalf("got total=%v used=%v, want 85 / 81.11", total, used)
+	}
+}
+
+// newTestBridge builds a Bridge with an offline XMPP bridge attached.
+// NewBridge leaves b.xmpp nil, and handleStreamDelta dereferences it, so the
+// field must be set by hand. SetPresence and ChatStateTo both return early
+// while offline, so presence/typing state is observable without a connection.
+func newTestBridge(acct ResolvedAccount) *Bridge {
+	b := NewBridge(acct, false)
+	b.xmpp = NewXMPPBridge(acct, func(InboundMessage) {}, func(string, string) {})
+	return b
+}
+
+// streamDelta builds a pi >= 0.84.0 message_update event: an
+// assistantMessageEvent delta and nothing else. Pi 0.84.0 removed the
+// cumulative `message` field and `assistantMessageEvent.partial`, so any event
+// this helper cannot express is one pi no longer sends.
+func streamDelta(ame map[string]any) Event {
+	return Event{"type": "message_update", "assistantMessageEvent": ame}
+}
+
+// TestStreamDeltaContract pins pi's post-0.84.0 message_update contract:
+// handleStreamDelta must drive presence and the typing bubble from deltas
+// alone. If a future edit reaches for a cumulative field, this test fails
+// because the events here never carry one.
+func TestStreamDeltaContract(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Owner: "zach@x"})
+
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "thinking_start"}))
+	if b.xmpp.show != "dnd" || b.xmpp.presence != "thinking…" {
+		t.Errorf("thinking_start presence = (%q,%q), want (dnd,thinking…)",
+			b.xmpp.show, b.xmpp.presence)
+	}
+
+	// 1:1 account: text_start lights the owner's composer immediately.
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "text_start"}))
+	if b.xmpp.presence != "replying…" {
+		t.Errorf("text_start presence = %q, want replying…", b.xmpp.presence)
+	}
+	if b.typingTo != "zach@x" {
+		t.Errorf("text_start typing target = %q, want zach@x", b.typingTo)
+	}
+
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "text_delta", "delta": "hello"}))
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "text_end"}))
+	if b.typingTo != "" {
+		t.Errorf("text_end typing target = %q, want empty", b.typingTo)
+	}
+
+	// An event with no assistantMessageEvent is ignored, not a panic.
+	b.handleStreamDelta(Event{"type": "message_update"})
+}
+
+// TestStreamDeltaContractRoomMode covers the room-mode branch, where the
+// typing target is decided from the accumulated text_delta chunks rather than
+// lit on the owner at text_start. Only the deltas carry that text now, so this
+// pins streamTypingDelta to ame["delta"].
+func TestStreamDeltaContractRoomMode(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Owner: "zach@x", Rooms: []string{"team@muc.x"}})
+
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "text_start"}))
+	if b.typingTo != "" {
+		t.Errorf("room-mode text_start typing target = %q, want empty (route unknown)", b.typingTo)
+	}
+
+	// The routing line arrives split across deltas, as it does on the wire.
+	for _, d := range []string{"to: ", "zach", "@x\n", "hi"} {
+		b.handleStreamDelta(streamDelta(map[string]any{"type": "text_delta", "delta": d}))
+	}
+	if b.typingTo != "zach@x" {
+		t.Errorf("room-mode typing target = %q, want zach@x", b.typingTo)
+	}
+
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "text_end"}))
+	if b.typingTo != "" {
+		t.Errorf("room-mode text_end typing target = %q, want empty", b.typingTo)
+	}
+}
+
+// TestClearQueueCounts verifies /abort's queue drain: the dropped count is the
+// sum of pi's steering and follow-up queues.
+func TestClearQueueCounts(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Owner: "zach@x"})
+	b.ctx = context.Background()
+	b.rpc = NewRPCClient(fakePiRespond(t, clearQueueOK), "", "", "", nil)
+	if err := b.rpc.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer b.rpc.Stop()
+
+	if got := b.clearQueue(); got != 2 {
+		t.Errorf("clearQueue() = %d, want 2 (1 steer + 1 follow-up)", got)
+	}
+}
+
+// TestClearQueueOldPi verifies the degrade path: pi < 0.84.4 has no
+// clear_queue, and an unknown-command failure must report 0 dropped rather
+// than blocking the abort that follows it.
+func TestClearQueueOldPi(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Owner: "zach@x"})
+	b.ctx = context.Background()
+	b.rpc = NewRPCClient(fakePiRespond(t, clearQueueUnknown), "", "", "", nil)
+	if err := b.rpc.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer b.rpc.Stop()
+
+	if got := b.clearQueue(); got != 0 {
+		t.Errorf("clearQueue() against pi < 0.84.4 = %d, want 0", got)
 	}
 }

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -772,9 +772,9 @@ func TestUnansweredRunCounts(t *testing.T) {
 	b := newTestBridge(ResolvedAccount{Owner: "zach@x"})
 	// The live A–E burst: 5 messages in, 1 reply out.
 	for range 5 {
-		b.countInbound()
+		b.countInbound("zach", "", "hello")
 	}
-	b.countDelivery()
+	b.recordDelivery("id-r", "answered")
 	in, out, ok := b.unansweredRun()
 	if !ok || in != 5 || out != 1 {
 		t.Errorf("A–E burst = (%d,%d,%v), want (5,1,true)", in, out, ok)
@@ -782,8 +782,8 @@ func TestUnansweredRunCounts(t *testing.T) {
 	// Every message answered → silent.
 	b.resetRunCounts()
 	for range 3 {
-		b.countInbound()
-		b.countDelivery()
+		b.countInbound("zach", "", "hello")
+		b.recordDelivery("id-r", "answered")
 	}
 	if _, _, ok := b.unansweredRun(); ok {
 		t.Error("a run that answered every message must not hint")
@@ -791,14 +791,14 @@ func TestUnansweredRunCounts(t *testing.T) {
 	// A single unanswered message is the empty-tail case, not this one: the
 	// "done (no reply)" banner and the tail recovery already cover it.
 	b.resetRunCounts()
-	b.countInbound()
+	b.countInbound("zach", "", "hello")
 	if _, _, ok := b.unansweredRun(); ok {
 		t.Error("a single-message run must not hint")
 	}
 	// Volunteer and reaction-ack runs stay quiet even when unbalanced.
 	b.resetRunCounts()
-	b.countInbound()
-	b.countInbound()
+	b.countInbound("zach", "", "hello")
+	b.countInbound("zach", "", "hello")
 	b.volunteered = true
 	if _, _, ok := b.unansweredRun(); ok {
 		t.Error("a volunteer run must not hint")
@@ -832,18 +832,65 @@ func TestUnansweredHintBounded(t *testing.T) {
 // tally, so a run the agent answered with "to: noop" is never nagged.
 func TestNoopCountsTowardAnsweredRun(t *testing.T) {
 	b := newTestBridge(ResolvedAccount{Rooms: []string{"team@muc.x"}, Owner: "zach@x"})
-	b.countInbound()
-	b.countInbound()
+	b.countInbound("zach", "", "hello")
+	b.countInbound("zach", "", "hello")
 	if !b.deliverReply("to: zach@x\n\nanswered one") {
 		// Offline, so this send reports undelivered; count it by hand to model
 		// the online case.
-		b.countDelivery()
+		b.recordDelivery("id-r", "answered")
 	}
 	if b.deliverReply("to: noop\n\nnothing more to add") {
-		b.countDelivery()
+		b.recordDelivery("id-r", "answered")
 	}
 	if _, _, ok := b.unansweredRun(); ok {
 		t.Error("a run answered with a reply plus to: noop must not hint")
+	}
+}
+
+// TestNoopWorksInOneToOne pins that a pure 1:1 account can decline to speak.
+// It has no routing contract, but "to: noop" is how the agent says "nothing to
+// send" — without it a deliberate silence looks like a reply that went missing,
+// and the bridge argues with it.
+func TestNoopWorksInOneToOne(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Owner: "zach@x"})
+	if !b.deliverReply("to: noop\n\nnothing more to add") {
+		t.Error("a 1:1 \"to: noop\" must count as an answer")
+	}
+	if !b.replied() {
+		t.Error("a 1:1 \"to: noop\" must mark the run as replied")
+	}
+	if _, out, _ := b.unansweredRun(); out != 1 {
+		t.Errorf("deliveries = %d, want 1", out)
+	}
+	// Only the FIRST non-empty line routes. Prose that merely mentions the form
+	// is an ordinary reply, and offline it reaches nobody.
+	b.resetRunCounts()
+	if b.deliverReply("Sure.\nto: noop") {
+		t.Error("a \"to: noop\" after the first line must not be a route")
+	}
+	if leadingNoop("to be fair, noop is a word") {
+		t.Error("prose beginning with \"to\" must not be a route")
+	}
+}
+
+// TestFanOutCountsEachSegment pins that one reply answering several messages is
+// counted as several answers. Counting per assistant message made a run that
+// answered everything look unbalanced, and the unanswered-message hint then
+// fired for work that was already done.
+func TestFanOutCountsEachSegment(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Rooms: []string{"team@muc.x"}, Owner: "zach@x"})
+	b.countInbound("zach", "id-a", "first question")
+	b.countInbound("zach", "id-b", "second question")
+	// Two segments in ONE message. "to: noop" is used because an offline send
+	// reaches nobody and so is not an answer.
+	if !b.deliverReply("to: noop\n\nanswer to A\nto: noop\n\nanswer to B") {
+		t.Fatal("precondition: a noop segment must deliver")
+	}
+	if _, out, _ := b.unansweredRun(); out != 2 {
+		t.Errorf("deliveries = %d, want 2 (one per \"to:\" segment)", out)
+	}
+	if _, _, ok := b.unansweredRun(); ok {
+		t.Error("a run that answered both messages in one reply must not hint")
 	}
 }
 
@@ -851,8 +898,8 @@ func TestNoopCountsTowardAnsweredRun(t *testing.T) {
 // the next one and fire a hint for cancelled work.
 func TestSettleClearsRunCounts(t *testing.T) {
 	b := newTestBridge(ResolvedAccount{Owner: "zach@x"})
-	b.countInbound()
-	b.countInbound()
+	b.countInbound("zach", "", "hello")
+	b.countInbound("zach", "", "hello")
 	if _, _, ok := b.unansweredRun(); !ok {
 		t.Fatal("precondition: 2 in / 0 out should hint")
 	}
@@ -870,9 +917,9 @@ func TestHintNotRepeatedOnTheCatchUpRun(t *testing.T) {
 	b := newTestBridge(ResolvedAccount{Owner: "zach@x"})
 	b.markHintPending() // as fireUnansweredHint does
 	// The catch-up run: even an unbalanced tally must not hint again.
-	b.countInbound()
-	b.countInbound()
-	b.countInbound()
+	b.countInbound("zach", "", "hello")
+	b.countInbound("zach", "", "hello")
+	b.countInbound("zach", "", "hello")
 	if !b.takeHintPending() {
 		t.Fatal("the run after a hint must be marked as the catch-up run")
 	}

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -44,11 +44,16 @@ Rules:
 
 ### Choosing a destination
 
-- **Answer a specific message** — the prompt's `stanza-id:` value (see below).
+The jid forms are the default. Use a stanza id only when a bare jid does not
+say which message a reply answers — several outstanding messages from the same
+room or person.
+
 - **Reply where the message came from** — the prompt's `from:` JID.
 - **DM the person who sent it** — the prompt's `sender:` JID (room messages).
 - **Reach the owner** — `to: <owner-jid>` (per-account `owner` in config).
 - **A joined room** → groupchat; the owner or a known occupant → `1:1` chat.
+- **Answer one message out of several** — the prompt's `stanza-id:` value (see
+  below).
 
 ### Answering one message: `to: <stanza-id>`
 
@@ -105,6 +110,13 @@ XEP-0359. The model knows which message it answers, so it names one.
 - Sends **no stanza** at all.
 - Counts as having replied, so the "done (no reply)" nudge does not turn room
   silence into owner DM noise.
+- Discards any body that follows it.
+- Works in **1:1 mode too** (`leadingNoop`), which parses no other `to:` form.
+  A 1:1 account has no routing contract, but it still needs a way to say
+  "nothing to send": without one, a deliberate silence looks like a reply that
+  went missing, and the empty-tail recovery and the unanswered-message hint both
+  argue with it. Only the **first non-empty line** routes — a `to: noop` further
+  down a 1:1 reply is ordinary text and is sent as written.
 
 ### Addressing other agents in a room
 
@@ -139,10 +151,26 @@ answer. When a run takes in two or more messages and sends fewer replies,
 `fireUnansweredHint` asks the agent once per user turn to check for messages
 that still need an answer.
 
-The hint asks for `to: <jid|stanza-id>` and prefers the stanza id. This is
-exactly the case a bare jid cannot disambiguate: several messages are in play,
-and only the id says which one a reply is for. `to: noop` is the explicit way
-for the agent to say its replies already covered everything.
+`recordDelivery` counts one answer per **delivered segment**, not per assistant
+message. One reply with three `to:` lines is three answers. Counting it as one
+made a run that answered every message look unbalanced, and the hint then fired
+for work that was already done.
+
+The hint prints the run's chat history: every message that came in and every
+reply that went out, in arrival order, each with its stanza id. The agent cannot
+see the XMPP traffic, so the two counts alone ("3 in, 2 out") leave it to
+reconstruct the run from its own context, and it gets that wrong. The history
+turns the check into a comparison. A long body is excerpted to its first few
+words (`hintExcerpt`); a `to: noop` shows as a deliberate silence.
+
+The hint asks for `to: <jid|stanza-id>`. Here a stanza id is the useful form:
+several messages are in play, and only the id says which one a reply is for.
+`to: noop` is the explicit way for the agent to say its replies already covered
+everything.
+
+In 1:1 mode the hint asks for no routing line at all — that account parses none,
+so the literal text would reach the owner. It asks for the outstanding answers
+and offers `to: noop`, which works in both modes.
 
 ## On-start seed
 

--- a/reply_test.go
+++ b/reply_test.go
@@ -212,16 +212,70 @@ func TestStreamTypingTargetStanzaID(t *testing.T) {
 // form, and keep "to: noop" as the way to say the replies already covered
 // everything.
 func TestUnansweredHintOffersStanzaID(t *testing.T) {
-	got := unansweredHintText(5, 1)
+	got := unansweredHintText(5, 1, nil, true)
 	for _, want := range []string{
-		"Received 5 messages but sent 1 replies",
+		"You received 5 messages but sent 1 replies",
 		`"to: <jid|stanza-id>"`,
-		`"stanza-id:"`,
 		`"to: noop"`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("hint is missing %s:\n%s", want, got)
 		}
+	}
+}
+
+// A pure 1:1 account parses no "to: <destination>" line, so the hint must not
+// ask for one: the literal text would land in front of the owner. "to: noop"
+// works in both modes and stays.
+func TestUnansweredHintOneToOneWording(t *testing.T) {
+	got := unansweredHintText(3, 1, nil, false)
+	if strings.Contains(got, "jid") || strings.Contains(got, "stanza-id>") {
+		t.Errorf("the 1:1 hint must not ask for a routing line:\n%s", got)
+	}
+	if !strings.Contains(got, `"to: noop"`) {
+		t.Errorf("the 1:1 hint must still offer \"to: noop\":\n%s", got)
+	}
+}
+
+// The agent cannot see the XMPP traffic, so counts alone leave it guessing
+// which message it missed. The hint must print the run's history: each message
+// in and each reply out, with the stanza id that answers it.
+func TestUnansweredHintShowsHistory(t *testing.T) {
+	got := unansweredHintText(3, 2, []runLogEntry{
+		{who: "zach", id: "id-a", text: "check the log"},
+		{who: "zach", id: "id-b", text: "also the metrics"},
+		{who: "slippy", id: "id-c", text: "the log looks clean", sent: true},
+		{who: "zach", id: "id-d", text: "and the disk"},
+		{who: "slippy", id: "", text: "", sent: true},
+	}, true)
+	for _, want := range []string{
+		`zach: id-a "check the log"`,
+		`zach: id-b "also the metrics"`,
+		`slippy: id-c "the log looks clean"`,
+		`zach: id-d "and the disk"`,
+		"slippy: (no id) (deliberate silence, to: noop)",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("history is missing %s:\n%s", want, got)
+		}
+	}
+	// The lines must stay in arrival order, or the agent cannot pair a reply
+	// with the message it answered.
+	if strings.Index(got, "id-a") > strings.Index(got, "id-d") {
+		t.Errorf("history is out of order:\n%s", got)
+	}
+}
+
+// A long message is excerpted, not repeated in full: the history is an index
+// into the run, and the messages themselves are already in the agent's context.
+func TestHintExcerptShortens(t *testing.T) {
+	long := strings.Repeat("word ", 40)
+	got := hintExcerpt(long)
+	if len([]rune(got)) > 50 || !strings.HasSuffix(got, "…") {
+		t.Errorf("excerpt = %q, want a short string ending in an ellipsis", got)
+	}
+	if got := hintExcerpt("two\nlines"); got != "two lines" {
+		t.Errorf("excerpt = %q, want the newline folded to a space", got)
 	}
 }
 

--- a/rpc.go
+++ b/rpc.go
@@ -38,6 +38,14 @@ func (e Event) Obj(k string) Event {
 	return nil
 }
 
+// Arr returns array field k as []any, or nil.
+func (e Event) Arr(k string) []any {
+	if a, ok := e[k].([]any); ok {
+		return a
+	}
+	return nil
+}
+
 // success reports whether a response event indicates success.
 func (e Event) success() bool { return e.Bool("success") }
 
@@ -355,6 +363,20 @@ func (c *RPCClient) SetSessionName(ctx context.Context, name string) (Event, err
 }
 
 func (c *RPCClient) Abort() { c.Send(map[string]any{"type": "abort"}) }
+
+// ClearQueue removes pi's queued steering and follow-up messages and returns
+// their text under data.steering / data.followUp. Requires pi >= 0.84.4; older
+// pi answers with an unknown-command failure, which callers must tolerate.
+//
+// Pi's documented order is clear_queue BEFORE abort: `abort` on its own leaves
+// the queue intact, so a steer that landed mid-run would start a fresh run the
+// instant the aborted one stops.
+func (c *RPCClient) ClearQueue(ctx context.Context) (Event, error) {
+	// Short timeout on purpose: this sits in front of /abort, which must feel
+	// immediate. Pi reads its stdin continuously, so a live pi answers well
+	// inside this. An unresponsive one costs the drain, not the abort.
+	return c.Request(ctx, map[string]any{"type": "clear_queue"}, 3*time.Second)
+}
 
 // CancelUI declines a pi UI request dialog (nobody is at the TUI to answer).
 func (c *RPCClient) CancelUI(id string) {

--- a/rpc_test.go
+++ b/rpc_test.go
@@ -91,3 +91,59 @@ func TestRequestAfterExitFails(t *testing.T) {
 		t.Error("expected error requesting after exit, got nil")
 	}
 }
+
+// fakePiRespond writes a `pi --mode rpc` stand-in that answers every id-bearing
+// command with respFmt, a printf template taking the request id as its single
+// %s argument. It lets a test dictate the response body for one command shape
+// (success with data, or an unknown-command failure) without a real pi.
+func fakePiRespond(t *testing.T, respFmt string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fakepi.sh")
+	script := `#!/bin/sh
+printf '{"type":"agent_start"}\n'
+while IFS= read -r line; do
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
+  if [ -n "$id" ]; then
+    printf '` + respFmt + `\n' "$id"
+  fi
+done
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fakepi: %v", err)
+	}
+	return path
+}
+
+// clearQueueOK answers clear_queue the way pi >= 0.84.4 does: one queued steer
+// and one queued follow-up.
+const clearQueueOK = `{"type":"response","id":"%s","success":true,"data":{"steering":["change direction"],"followUp":["summarize"]}}`
+
+// clearQueueUnknown is how pi < 0.84.4 answers: the command does not exist.
+const clearQueueUnknown = `{"type":"response","id":"%s","success":false,"error":"unknown command: clear_queue"}`
+
+func TestClearQueueResponse(t *testing.T) {
+	c := NewRPCClient(fakePiRespond(t, clearQueueOK), "", "", "", nil)
+	if err := c.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer c.Stop()
+
+	res, err := c.ClearQueue(context.Background())
+	if err != nil {
+		t.Fatalf("ClearQueue: %v", err)
+	}
+	if !res.success() {
+		t.Fatalf("ClearQueue success = false, want true")
+	}
+	data := res.Obj("data")
+	if got := len(data.Arr("steering")); got != 1 {
+		t.Errorf("steering len = %d, want 1", got)
+	}
+	if got := len(data.Arr("followUp")); got != 1 {
+		t.Errorf("followUp len = %d, want 1", got)
+	}
+	if got := data.Arr("missing"); got != nil {
+		t.Errorf("Arr on a missing key = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Why

The unanswered-message hint gave the agent two counts — "Received 3 messages but sent 2 replies" — and nothing else. The agent cannot see the XMPP traffic, so it tried to reconstruct the run from its own context and got it wrong.

## What

- **History block.** The hint now prints the run's chat history: every message in and every reply out, in arrival order, each with its stanza id and a short excerpt (48 runes, then `…`). A `to: noop` shows as a deliberate silence.

```
[pi-msg] You received 3 messages but sent 2 replies. Make sure that your replies addressed all 3 received messages. Here is this run's chat history in XMPP, in order, with the stanza id of each message:

zach: 3e2597d4-a470-4cdb-b972-431043bce34f "can you check the deploy log for slippy and…"
zach: aa11bb22cc33dd44 "also what is the disk usage"
slippy: bb22cc33dd44ee55 "The deploy log is clean, no errors since 16:20."
zach: cc33dd44ee55ff66 "and restart the unit when you are done"
slippy: (no id) (deliberate silence, to: noop)

If anything is outstanding reply to it now using "to: <jid|stanza-id>" — …
```

- **Routing seed.** It now reads `to: <jid|stanza-id>` and tells the agent to default to the jid form. It names the id form only for the case a bare jid cannot show: which of several messages a reply answers.
- **`to: noop` in 1:1 mode** (`leadingNoop`). A 1:1 account parses no other `to:` form, but it still needs a way to say "nothing to send" — without one a deliberate silence looks like a reply that went missing. Only the first non-empty line routes. The 1:1 hint asks for no routing line, because that account parses none.
- **Fan-out undercount fixed.** `recordDelivery` counts one answer per delivered segment, not per assistant message. One reply with three `to:` lines is three answers. Counting it as one made a run that answered every message look unbalanced, and the hint then fired for work that was already done.

## Tests

New: `TestUnansweredHintShowsHistory`, `TestHintExcerptShortens`, `TestUnansweredHintOneToOneWording`, `TestNoopWorksInOneToOne`, `TestFanOutCountsEachSegment`. `go vet`, `go test -race`, and `gofmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wiXgyyXzfiPUwoHJ7493W