### PR TITLE
feat: show dnd while background processes are running

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -96,6 +96,7 @@ type Bridge struct {
 	idleSince      time.Time // when the agent last became idle; zero while a run is in flight
 	awayAnnounced  bool      // the away transition has been announced this idle period
 	lastAwayStatus string    // the last pithy activity shown while away (skip repeats across periods)
+	bgProcesses    int       // background processes pi has running (relayed by the pi-processes extension)
 
 	lifecycleReactTo string // snapshot of reactTo at run start, for lifecycle auto-reacts
 	lifecycleReactID string // snapshot of reactID at run start; never overwritten by deliverReply
@@ -388,7 +389,7 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		b.setStreaming(false)
 		b.stopTyping()
 		b.markIdle() // now idle — arm the away clock and stamp the XEP-0319 idle element
-		b.xmpp.SetPresence("", "listening")
+		b.announceSettledPresence()
 		b.lifecycleReact("✅") // done
 		// The routing reminder decision happens here (issue #16): mid-run
 		// malformed commentary drops silently, and the agent is only nudged if
@@ -514,12 +515,13 @@ func (b *Bridge) handleUIRequest(ev Event) {
 // `file:` text conventions (issue #8 spike).
 func (b *Bridge) handleToolRelay(id, payload string) {
 	var cmd struct {
-		Action    string `json:"action"`
-		Emoji     string `json:"emoji"`
-		Path      string `json:"path"`
-		To        string `json:"to"`
-		MessageID string `json:"messageId"`
-		From      string `json:"from"`
+		Action       string `json:"action"`
+		Emoji        string `json:"emoji"`
+		Path         string `json:"path"`
+		To           string `json:"to"`
+		MessageID    string `json:"messageId"`
+		From         string `json:"from"`
+		ProcessCount int    `json:"count"`
 	}
 	if err := json.Unmarshal([]byte(payload), &cmd); err != nil {
 		b.log("warning", "bad tool-relay payload: "+err.Error())
@@ -585,6 +587,12 @@ func (b *Bridge) handleToolRelay(id, payload string) {
 			}
 			b.rpc.RespondUIRelay(id, url)
 		}()
+	case "process_count":
+		// Absolute count of background processes pi has running (relayed by the
+		// pi-processes companion extension). While any run — or any background
+		// process — is in flight, the bot shows dnd instead of available.
+		b.setBgProcesses(cmd.ProcessCount)
+		b.rpc.RespondUIRelay(id, "ok")
 	default:
 		b.log("warning", "unknown tool-relay action: "+cmd.Action)
 		b.rpc.RespondUIRelay(id, "unknown tool-relay action: "+cmd.Action)
@@ -616,7 +624,7 @@ func (b *Bridge) onInbound(m InboundMessage) {
 	b.markActive()
 	b.markIdle()
 	if !b.streaming() && b.xmpp != nil {
-		b.xmpp.SetPresence("", "listening")
+		b.announceSettledPresence()
 	}
 	// An inbound XEP-0444 reaction is an acknowledgment signal, not a
 	// conversation turn: surface it as ambient context for the agent's next
@@ -2735,7 +2743,7 @@ func (b *Bridge) settleLocally() {
 	b.setStreaming(false)
 	b.stopTyping()
 	b.markIdle()
-	b.xmpp.SetPresence("", "listening")
+	b.announceSettledPresence()
 	b.clearPendingNudge() // aborted run — discard any staged correction (#16)
 	// Aborted or replaced run: drop the empty-tail bookkeeping so a recovery
 	// prompt can't fire for work the user already cancelled.
@@ -2795,6 +2803,51 @@ var awayActivities = []string{
 	"performing maintenance on the hourglass",
 	"re-sequencing the days of the week",
 	"mending the nets for dream-catching",
+}
+
+// setBgProcesses records the absolute number of background processes pi has
+// running, relayed by the pi-processes companion extension, and reflects it in
+// presence: while any process runs (and no agent run is in flight) the bot
+// shows dnd "background process running" instead of available, and the idle
+// watcher must not drift it to "away" mid-build. Absolute counts self-heal — a
+// missed started/ended relay is corrected by the next one.
+func (b *Bridge) setBgProcesses(n int) {
+	b.mu.Lock()
+	if n < 0 {
+		n = 0
+	}
+	changed := n != b.bgProcesses
+	b.bgProcesses = n
+	streaming := b.streamingRun
+	b.mu.Unlock()
+	if !changed || b.xmpp == nil {
+		return
+	}
+	if streaming {
+		return // a run in flight already forces dnd with its own activity label
+	}
+	b.announceSettledPresence()
+}
+
+// announceSettledPresence sets the presence of an idle agent: available +
+// "listening", unless a background process is still running, which keeps the
+// bot dnd.
+func (b *Bridge) announceSettledPresence() {
+	if b.xmpp == nil {
+		return
+	}
+	b.mu.Lock()
+	bg := b.bgProcesses
+	b.mu.Unlock()
+	if bg > 0 {
+		noun := "processes"
+		if bg == 1 {
+			noun = "process"
+		}
+		b.xmpp.SetPresence("dnd", fmt.Sprintf("waiting on %d %s", bg, noun))
+	} else {
+		b.xmpp.SetPresence("", "listening")
+	}
 }
 
 // markIdle records that the agent has settled into an idle, available state;
@@ -2878,7 +2931,8 @@ func (b *Bridge) idleTick() {
 	elapsed := time.Since(b.idleSince)
 	// Read streamingRun directly rather than via streaming(), which re-locks
 	// b.mu and would deadlock this goroutine against itself.
-	if !idle || b.streamingRun || elapsed < idleAwayTimeout || b.xmpp == nil || b.awayAnnounced {
+	// Background processes keep the bot dnd (never drift to away mid-build).
+	if !idle || b.streamingRun || b.bgProcesses > 0 || elapsed < idleAwayTimeout || b.xmpp == nil || b.awayAnnounced {
 		b.mu.Unlock()
 		return
 	}

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -1092,3 +1092,140 @@ func TestClearQueueOldPi(t *testing.T) {
 		t.Errorf("clearQueue() against pi < 0.84.4 = %d, want 0", got)
 	}
 }
+
+// bgBridge is a room-mode bridge with a mock XMPP bridge whose SetPresence
+// calls are observable through show/presence.
+func bgBridge() *Bridge {
+	b := roomBridge()
+	b.xmpp = &XMPPBridge{}
+	return b
+}
+
+// TestBgProcessesPresence pins the dnd-while-waiting contract: while pi has
+// background processes running and no agent run is in flight, presence shows
+// dnd with a count label; zero processes settle back to "listening".
+func TestBgProcessesPresence(t *testing.T) {
+	b := bgBridge()
+
+	// No processes: settled presence is available + listening.
+	b.announceSettledPresence()
+	if b.xmpp.show != "" || b.xmpp.presence != "listening" {
+		t.Errorf("settled with 0 processes = show %q status %q, want available \"listening\"", b.xmpp.show, b.xmpp.presence)
+	}
+
+	// A process starts: dnd with the plural label.
+	b.setBgProcesses(2)
+	if b.xmpp.show != "dnd" || b.xmpp.presence != "waiting on 2 processes" {
+		t.Errorf("2 processes = show %q status %q, want dnd \"waiting on 2 processes\"", b.xmpp.show, b.xmpp.presence)
+	}
+
+	// Singular label for exactly one process.
+	b.setBgProcesses(1)
+	if b.xmpp.presence != "waiting on 1 process" {
+		t.Errorf("1 process status = %q, want \"waiting on 1 process\"", b.xmpp.presence)
+	}
+
+	// Settling again (agent run ends) keeps dnd while a process still runs.
+	b.announceSettledPresence()
+	if b.xmpp.show != "dnd" {
+		t.Errorf("settled with 1 process = show %q, want dnd", b.xmpp.show)
+	}
+
+	// Last process ends: back to listening.
+	b.setBgProcesses(0)
+	if b.xmpp.show != "" || b.xmpp.presence != "listening" {
+		t.Errorf("0 processes after being busy = show %q status %q, want listening", b.xmpp.show, b.xmpp.presence)
+	}
+
+	// No-change relay is a no-op (SetPresence skips identical stanzas anyway,
+	// but the count must not be flipped to 0 by a stale relay).
+	b.setBgProcesses(0)
+	if b.xmpp.show != "" || b.xmpp.presence != "listening" {
+		t.Errorf("redundant 0 relay changed presence to %q/%q", b.xmpp.show, b.xmpp.presence)
+	}
+}
+
+// TestBgProcessesDontDriftAway pins the idle-watcher interaction: a bot
+// waiting on background processes must not announce "away" no matter how long
+// it sits idle. awayAnnounced staying false is the observable — the transition
+// was suppressed.
+func TestBgProcessesDontDriftAway(t *testing.T) {
+	b := bgBridge()
+	b.idleSince = time.Now().Add(-idleAwayTimeout - time.Minute)
+	b.bgProcesses = 1
+	b.awayAnnounced = false
+
+	b.idleTick()
+
+	if b.awayAnnounced {
+		t.Error("idleTick announced away while a background process was running")
+	}
+	if b.xmpp.presence == "away" || b.xmpp.show == "away" {
+		t.Errorf("presence drifted to away: %q/%q", b.xmpp.show, b.xmpp.presence)
+	}
+
+	// Once the process finishes and the agent stays idle, away is allowed again.
+	b.bgProcesses = 0
+	b.idleTick()
+	if !b.awayAnnounced {
+		t.Error("idleTick should announce away once processes finished")
+	}
+	if b.xmpp.show != "away" {
+		t.Errorf("presence after idle = show %q, want away", b.xmpp.show)
+	}
+}
+
+// TestSettledPresenceRespectsRunningProcesses: an agent_settled must leave the
+// bot dnd when background processes are still running (the run's own end does
+// not finish the work) — and a process starting must not stamp over a live run.
+func TestSettledPresenceRespectsRunningProcesses(t *testing.T) {
+	b := bgBridge()
+	b.setBgProcesses(1)
+	b.announceSettledPresence()
+	if b.xmpp.show != "dnd" {
+		t.Errorf("agent_settled with 1 process = show %q, want dnd", b.xmpp.show)
+	}
+
+	// A process starting mid-run must not clobber the run's own label.
+	b.streamingRun = true
+	b.xmpp.SetPresence("dnd", "thinking…")
+	b.setBgProcesses(2)
+	if b.xmpp.presence != "thinking…" {
+		t.Errorf("process relay mid-run clobbered run label: %q", b.xmpp.presence)
+	}
+}
+
+// TestToolRelayProcessCount exercises the process_count relay action: the
+// count lands on the bridge and the relay answers "ok".
+func TestToolRelayProcessCount(t *testing.T) {
+	var buf bytes.Buffer
+	b := bgBridge()
+	b.rpc = &RPCClient{stdin: &nopClose{buf: &buf}, mu: sync.Mutex{}}
+
+	b.handleToolRelay("r-count", `{"action":"process_count","count":3}`)
+
+	deadline := time.Now().Add(2 * time.Second)
+	var line string
+	for {
+		if l, err := buf.ReadString('\n'); err == nil {
+			line = l
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no relay response within 2s (buf=%q)", buf.String())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !strings.Contains(line, "\"value\": \"ok\"") && !strings.Contains(line, "\"value\":\"ok\"") {
+		t.Errorf("process_count relay response = %q, want ok", line)
+	}
+	b.mu.Lock()
+	got := b.bgProcesses
+	b.mu.Unlock()
+	if got != 3 {
+		t.Errorf("bgProcesses after relay = %d, want 3", got)
+	}
+	if b.xmpp.presence != "waiting on 3 processes" {
+		t.Errorf("presence after relay = %q, want \"waiting on 3 processes\"", b.xmpp.presence)
+	}
+}

--- a/piext/xmpp-tools.ts
+++ b/piext/xmpp-tools.ts
@@ -43,8 +43,63 @@ export default function xmppTools(pi: ExtensionAPI) {
 	// Captured on session_start; used by tool handlers to reach pi-msg.
 	let ui: RelayUI | undefined;
 
-	pi.on("session_start", (_event, ctx) => {
+	// --- Background-process presence tracking ---
+	//
+	// The pi-processes extension broadcasts every process lifecycle change on
+	// the shared bus (processes:started / processes:ended, via its
+	// event-bridge hook) and serves synchronous list queries on
+	// processes:request:list. pi-msg shows dnd while a background process
+	// runs, so we relay the manager's current process count over the same
+	// sentinel channel as the tools. Every change triggers a fresh query of
+	// the authoritative manager (never delta arithmetic, so counts can't
+	// drift), and the count is re-seeded on every session_start to cover
+	// processes that predate this extension instance — the registry is
+	// in-memory and dies with the pi process anyway.
+	const PROCESS_STARTED = "processes:started";
+	const PROCESS_ENDED = "processes:ended";
+	const PROCESS_LIST = "processes:request:list";
+
+	// queryProcessCount asks the pi-processes manager for its current process
+	// list over the in-process request channel (its reply is synchronous).
+	// Falls back to 0 if pi-processes isn't loaded or doesn't answer.
+	function queryProcessCount(): Promise<number> {
+		return new Promise((resolve) => {
+			let settled = false;
+			const done = (n: number) => {
+				if (!settled) {
+					settled = true;
+					resolve(n);
+				}
+			};
+			pi.events.emit(PROCESS_LIST, {
+				reply: (processes: unknown) => done(Array.isArray(processes) ? processes.length : 0),
+			});
+			setTimeout(() => done(0), 500);
+		});
+	}
+
+	async function refreshProcessCount() {
+		if (!ui) return;
+		try {
+			const count = await queryProcessCount();
+			await relay("process_count", { count });
+		} catch {
+			// Best-effort: presence is cosmetic; a dropped relay is harmless.
+		}
+	}
+
+	pi.events.on(PROCESS_STARTED, () => {
+		void refreshProcessCount();
+	});
+	pi.events.on(PROCESS_ENDED, () => {
+		void refreshProcessCount();
+	});
+
+	pi.on("session_start", async (_event, ctx) => {
 		ui = ctx.ui as unknown as RelayUI;
+		// Re-seed the background-process count from the manager so presence
+		// reflects processes that predate this extension instance.
+		await refreshProcessCount();
 	});
 
 	// Inject the agent's identity ($PI_MSG_ACCOUNT) at the top of every system


### PR DESCRIPTION
## What

pi-msg flips presence to `dnd` while an agent run is in flight, but a background process running while the agent is idle produced no events — so the bot sat at `listening` (available) mid-build.

This wires the pi-processes extension's lifecycle events into presence:

**`piext/xmpp-tools.ts`** — the companion extension now:
- subscribes to the pi-processes shared bus (`processes:started` / `processes:ended`, via its event-bridge hook)
- queries the manager's authoritative process list on each change (`processes:request:list`) and relays the count to pi-msg over the existing sentinel UI relay — absolute counts, never deltas, so state can't drift
- re-seeds on every `session_start`, covering processes that predate the extension (registry is in-memory)

**`bridge.go`** — pi-msg tracks the count and:
- announces `dnd` / `waiting on N processes` whenever any background process runs and no run is in flight (`announceSettledPresence`, which now backs `agent_settled`, `onInbound` idle resets, and `settleLocally`)
- suppresses the idle-away transition while processes run, so the bot never drifts to `away` mid-build

## Notes
- Singular/plural label: `waiting on 1 process` / `waiting on 2 processes`
- A run in flight keeps its own label (`thinking…` etc.); process relays never clobber it
- pi-processes absent → the seed query times out to 0 and everything behaves as before

## Tests
- `TestBgProcessesPresence` — label + transitions
- `TestBgProcessesDontDriftAway` — idleTick suppression
- `TestSettledPresenceRespectsRunningProcesses` — run/process interaction
- `TestToolRelayProcessCount` — relay action lands count + answers ok