### PR TITLE
fix: crashloop from session_start dialog relay

### DIFF
--- a/piext/xmpp-tools.ts
+++ b/piext/xmpp-tools.ts
@@ -95,11 +95,20 @@ export default function xmppTools(pi: ExtensionAPI) {
 		void refreshProcessCount();
 	});
 
-	pi.on("session_start", async (_event, ctx) => {
+	pi.on("session_start", (_event, ctx) => {
 		ui = ctx.ui as unknown as RelayUI;
-		// Re-seed the background-process count from the manager so presence
-		// reflects processes that predate this extension instance.
-		await refreshProcessCount();
+		// Deferred seed of the background-process count. This must NOT happen
+		// synchronously in the hook: pi's RPC mode attaches its stdin reader
+		// only after session_start hooks resolve, so blocking on a dialog
+		// (relay → ui.select) during session_start can never complete — the
+		// response can't be read — and any stdin traffic arriving meanwhile
+		// makes pi exit cleanly (crashloop). Deferring past bootstrap turns
+		// the seed into a normal post-start relay, exactly like the tool
+		// relays. Started/ended listeners below cover live changes; this only
+		// covers processes already tracked before the first relay.
+		setTimeout(() => {
+			void refreshProcessCount();
+		}, 2000);
 	});
 
 	// Inject the agent's identity ($PI_MSG_ACCOUNT) at the top of every system


### PR DESCRIPTION
## Root cause

The process-count feature (#63) relayed the count from the companion extension's `session_start` hook by **awaiting a dialog** (`ui.select` → sentinel relay). That is unusable in RPC mode:

- pi attaches its stdin reader **only after** all `session_start` hooks resolve (`rebindSession()` in rpc-mode.js precedes the JSONL reader).
- The hook therefore blocks on a select whose response can never be read → bootstrap stalls.
- Any stdin traffic pi-msg sends meanwhile (`get_state` on startup, etc.) makes pi exit cleanly (code 0) — reproduced locally: even writing `"hello there\n"` kills it.
- Every persona bridge hit `onPiExit` → exit-code failure → systemd crashloop. Reverted deploy.

## Fix

Defer the seed relay out of the bootstrap: `session_start` only captures the UI context and arms a 2s timer; the relay then runs exactly like the tool relays do (post-start, reader attached). The `processes:started`/`processes:ended` listeners are unchanged — they fire mid-run, never at bootstrap.

## Verification

Local reproduction against `pi --mode rpc`:
- **before**: respond+`get_state` → `PI EXITED code=0` (and garbage input also exits)
- **after**: bootstrap completes, deferred relay resolves `ok`, `get_state` succeeds, pi stays alive past 20s watchdog (also confirmed for garbage-input case)