### PR TITLE
Wake idle agent when a background process runs long

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -64,6 +64,7 @@ type Bridge struct {
 	turnDest       string        // reply destination for the current turn (owner or room jid)
 	routingSeeded  bool          // the pi-msg routing contract has been injected into this session (once)
 	reactionAckRun bool          // a run was woken by an inbound reaction ack (suppress "done (no reply)" noise)
+	heartbeatRun   bool          // a run was woken by a long-running-process heartbeat (noop is the expected outcome)
 	// finalMsgHadText records whether the most recent assistant message of this
 	// run carried deliverable text. A run that ends on a tool call leaves it
 	// false: the answer was never written, so nothing could be delivered.
@@ -391,7 +392,6 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		b.stopTyping()
 		b.markIdle() // now idle — arm the away clock and stamp the XEP-0319 idle element
 		b.announceSettledPresence()
-		b.flushPendingHeartbeats() // deliver any long-running-process alarms queued mid-run
 		b.lifecycleReact("✅") // done
 		// The routing reminder decision happens here (issue #16): mid-run
 		// malformed commentary drops silently, and the agent is only nudged if
@@ -423,14 +423,28 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		// The reply text + typing/presence already signal "done". Only nudge if
 		// the run produced no message, so silence isn't mistaken for a hang.
 		// A run woken purely by a reaction ack (reactionAckRun) is allowed to
-		// stay silent after a to:noop without touching the owner. A recovery
-		// prompt (tail retry or routing nudge) is in flight, so hold the
-		// banner: the retry may still answer, and "done (no reply)" followed
-		// by the resend would read as a contradiction.
-		if !b.replied() && !b.volunteered && !b.reactionAckRun && !recovering && !nudged {
+		// stay silent after a to:noop without touching the owner. So is a
+		// heartbeat wake (heartbeatRun): noop is exactly what the alarm asks
+		// for, and the "— your turn" would be a misleading prompt to the
+		// owner. A recovery prompt (tail retry or routing nudge) is in flight,
+		// so hold the banner: the retry may still answer, and "done (no
+		// reply)" followed by the resend would read as a contradiction.
+		if b.bannerNoReply(recovering, nudged) {
 			b.reply("✅ done (no reply) — your turn")
 		}
 		b.volunteered = false // a resume volunteer turn is a one-shot; never repeats
+		// A heartbeat wake is likewise one-shot: the flag lives only for the
+		// run it opened, so a later user-initiated run is judged normally. It
+		// is consumed here (like volunteered) rather than cleared at
+		// agent_start — the settle check above must still see it.
+		b.heartbeatRun = false
+		// Deliver any long-running-process alarms queued while the run just
+		// settled was in flight. This must come AFTER the banner decision and
+		// the flag consumption above: a flushed heartbeat sets heartbeatRun
+		// for the run it opens (the next one), and letting it bleed into this
+		// settle's check would suppress a legitimate "done (no reply)" for a
+		// user-initiated run that genuinely went unanswered.
+		b.flushPendingHeartbeats()
 	case "message_update":
 		b.handleStreamDelta(ev)
 	case "tool_execution_start":
@@ -1913,11 +1927,11 @@ func (b *Bridge) clearToolSinceDelivery() {
 //
 // A run that delivered its reply after the tool clears toolSinceDelivery, so it
 // never matches. Nor does a run that simply had nothing to do (no tool). A
-// volunteer or reaction-ack run is allowed to end quietly.
+// volunteer, reaction-ack, or heartbeat run is allowed to end quietly.
 func (b *Bridge) needsEmptyTailRecovery() bool {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.volunteered || b.reactionAckRun {
+	if b.volunteered || b.reactionAckRun || b.heartbeatRun {
 		return false
 	}
 	return b.toolSinceDelivery && !b.finalMsgHadText
@@ -2014,6 +2028,13 @@ func hintExcerpt(text string) string {
 // The counters are reset at settle rather than at agent_start because
 // handleCanonical counts a message before pi reports the run started: resetting
 // at agent_start would zero the very message that opened the run.
+func (b *Bridge) bannerNoReply(recovering, nudged bool) bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return !b.repliedThisRun && !b.volunteered && !b.reactionAckRun && !b.heartbeatRun && !recovering && !nudged
+}
+
+// resetRunCounts clears the per-run message/reply tally. Called at settle,
 func (b *Bridge) resetRunCounts() {
 	b.mu.Lock()
 	b.runInbound = 0
@@ -2032,7 +2053,7 @@ func (b *Bridge) resetRunCounts() {
 func (b *Bridge) unansweredRun() (inbound, delivered int, ok bool) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if b.volunteered || b.reactionAckRun {
+	if b.volunteered || b.reactionAckRun || b.heartbeatRun {
 		return 0, 0, false
 	}
 	return b.runInbound, b.runDeliveries, b.runInbound > 1 && b.runInbound > b.runDeliveries
@@ -3127,11 +3148,15 @@ func heartbeatTail(tail string) string {
 }
 
 // fireHeartbeat wakes the (idle) agent with a long-running-process alarm,
-// routing any response to the owner like the other synthetic prompts.
+// routing any response to the owner like the other synthetic prompts. The run
+// is marked heartbeatRun so its (expected) to:noop outcome is treated like a
+// volunteer or reaction-ack run: no "done (no reply)" banner, no recovery or
+// unanswered-message hints.
 func (b *Bridge) fireHeartbeat(text string) {
 	if text == "" {
 		return
 	}
+	b.heartbeatRun = true
 	b.setTurnDest(b.acct.Owner)
 	b.rpc.Prompt(text, b.steerBehavior())
 	b.xmpp.SetPresence("dnd", "thinking…")

--- a/bridge.go
+++ b/bridge.go
@@ -97,6 +97,7 @@ type Bridge struct {
 	awayAnnounced  bool      // the away transition has been announced this idle period
 	lastAwayStatus string    // the last pithy activity shown while away (skip repeats across periods)
 	bgProcesses    int       // background processes pi has running (relayed by the pi-processes extension)
+	pendingHeartbeats []string // long-running-process alarms queued while a run was in flight
 
 	lifecycleReactTo string // snapshot of reactTo at run start, for lifecycle auto-reacts
 	lifecycleReactID string // snapshot of reactID at run start; never overwritten by deliverReply
@@ -390,6 +391,7 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		b.stopTyping()
 		b.markIdle() // now idle — arm the away clock and stamp the XEP-0319 idle element
 		b.announceSettledPresence()
+		b.flushPendingHeartbeats() // deliver any long-running-process alarms queued mid-run
 		b.lifecycleReact("✅") // done
 		// The routing reminder decision happens here (issue #16): mid-run
 		// malformed commentary drops silently, and the agent is only nudged if
@@ -515,13 +517,14 @@ func (b *Bridge) handleUIRequest(ev Event) {
 // `file:` text conventions (issue #8 spike).
 func (b *Bridge) handleToolRelay(id, payload string) {
 	var cmd struct {
-		Action       string `json:"action"`
-		Emoji        string `json:"emoji"`
-		Path         string `json:"path"`
-		To           string `json:"to"`
-		MessageID    string `json:"messageId"`
-		From         string `json:"from"`
-		ProcessCount int    `json:"count"`
+		Action       string             `json:"action"`
+		Emoji        string             `json:"emoji"`
+		Path         string             `json:"path"`
+		To           string             `json:"to"`
+		MessageID    string             `json:"messageId"`
+		From         string             `json:"from"`
+		ProcessCount int                `json:"count"`
+		Processes    []HeartbeatProcess `json:"processes"`
 	}
 	if err := json.Unmarshal([]byte(payload), &cmd); err != nil {
 		b.log("warning", "bad tool-relay payload: "+err.Error())
@@ -593,10 +596,37 @@ func (b *Bridge) handleToolRelay(id, payload string) {
 		// process — is in flight, the bot shows dnd instead of available.
 		b.setBgProcesses(cmd.ProcessCount)
 		b.rpc.RespondUIRelay(id, "ok")
+	case "process_heartbeat":
+		// A long-running-process alarm from the companion extension (its
+		// 10-minute heartbeat tick). Wake the agent with it — unless a run is
+		// in flight, in which case queue the report and deliver it when the
+		// agent settles, so the alarm never interrupts an active turn and is
+		// never lost. The relay itself always answers ok: gathering the report
+		// is the extension's job; delivery timing is the bridge's.
+		text := b.formatHeartbeat(cmd.Processes)
+		if b.streaming() {
+			b.mu.Lock()
+			b.pendingHeartbeats = append(b.pendingHeartbeats, text)
+			b.mu.Unlock()
+			b.log("info", fmt.Sprintf("process heartbeat queued (%d process(es), run in flight)", len(cmd.Processes)))
+		} else {
+			b.fireHeartbeat(text)
+		}
+		b.rpc.RespondUIRelay(id, "ok")
 	default:
 		b.log("warning", "unknown tool-relay action: "+cmd.Action)
 		b.rpc.RespondUIRelay(id, "unknown tool-relay action: "+cmd.Action)
 	}
+}
+
+// HeartbeatProcess is one long-running background process reported by the
+// companion extension's heartbeat tick (see xmpp-tools.ts).
+type HeartbeatProcess struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Command     string `json:"command"`
+	ElapsedSecs int    `json:"elapsedSecs"`
+	Tail        string `json:"tail"`
 }
 
 // --- chat command handling ---
@@ -3054,6 +3084,72 @@ func startLabel(v string) string {
 		return "prompt"
 	}
 	return "auto (idle default)"
+}
+
+// formatHeartbeat renders the process-heartbeat alarm for the agent: one line
+// per long-running process with its true elapsed time and a log tail. Single
+// process → the terse Zack-flavored form; several → batched sections so the
+// agent is woken once with everything rather than once per process.
+func (b *Bridge) formatHeartbeat(procs []HeartbeatProcess) string {
+	if len(procs) == 1 {
+		p := procs[0]
+		return fmt.Sprintf(
+			"[pi-msg: process %q has been running for %d %s now. Here's the log tail:\n\n%s\n\nIf this is unexpected, determine what happened and act. If this is expected, reply with \"to: noop\" and nothing else.]",
+			p.Name, p.ElapsedSecs, heartbeatNoun(p.ElapsedSecs), heartbeatTail(p.Tail),
+		)
+	}
+	var sb strings.Builder
+	if len(procs) == 0 {
+		return ""
+	}
+	sb.WriteString("[pi-msg: " + strconv.Itoa(len(procs)) + " background processes have been running for a while. Here they are with log tails:")
+	for _, p := range procs {
+		fmt.Fprintf(&sb, "\n\n• %s — %d %s\n%s", p.Name, p.ElapsedSecs, heartbeatNoun(p.ElapsedSecs), heartbeatTail(p.Tail))
+	}
+	sb.WriteString("\n\nIf any of these is unexpected, determine what happened and act. If they are all expected, reply with \"to: noop\" and nothing else.]")
+	return sb.String()
+}
+
+// heartbeatNoun pluralizes the elapsed-seconds label; heartbeatTail renders the
+// log tail or a placeholder when the process has produced no output yet.
+func heartbeatNoun(n int) string {
+	if n == 1 {
+		return "second"
+	}
+	return "seconds"
+}
+
+func heartbeatTail(tail string) string {
+	if strings.TrimSpace(tail) == "" {
+		return "(no output yet)"
+	}
+	return tail
+}
+
+// fireHeartbeat wakes the (idle) agent with a long-running-process alarm,
+// routing any response to the owner like the other synthetic prompts.
+func (b *Bridge) fireHeartbeat(text string) {
+	if text == "" {
+		return
+	}
+	b.setTurnDest(b.acct.Owner)
+	b.rpc.Prompt(text, b.steerBehavior())
+	b.xmpp.SetPresence("dnd", "thinking…")
+	b.log("info", "process heartbeat injected")
+}
+
+// flushPendingHeartbeats delivers any heartbeats queued while a run was in
+// flight (their delivery was deferred rather than dropped). Called on
+// agent_settled, when the agent is idle again and safe to wake. Flushing one
+// at a time keeps each alarm its own turn; the agent can noop them individually.
+func (b *Bridge) flushPendingHeartbeats() {
+	b.mu.Lock()
+	queued := b.pendingHeartbeats
+	b.pendingHeartbeats = nil
+	b.mu.Unlock()
+	for _, text := range queued {
+		b.fireHeartbeat(text)
+	}
 }
 
 // fireResumeTurn injects a single synthetic prompt so the resumed agent can

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -1230,6 +1230,88 @@ func TestToolRelayProcessCount(t *testing.T) {
 	}
 }
 
+// TestHeartbeatRunNoBanner pins the fix: a heartbeat wake is one-shot —
+// fireHeartbeat sets heartbeatRun, it survives agent_start (so the settle-time
+// banner decision still sees it), and bannerNoReply returns false for it even
+// when the run produced no reply. A heartbeat-run noop must never surface the
+// misleading "done (no reply) — your turn" to the owner.
+func TestHeartbeatRunNoBanner(t *testing.T) {
+	var buf bytes.Buffer
+	b := bgBridge()
+	b.rpc = &RPCClient{stdin: &nopClose{buf: &buf}, mu: sync.Mutex{}}
+
+	// A heartbeat alarm wakes the idle agent and marks the run it opens.
+	b.fireHeartbeat(`[pi-msg: process "build" has been running for 600 seconds now…]`)
+	b.mu.Lock()
+	marked := b.heartbeatRun
+	b.mu.Unlock()
+	if !marked {
+		t.Fatal("fireHeartbeat must set heartbeatRun")
+	}
+
+	// agent_start must NOT clear it: the flag has to survive to the settle
+	// decision for the run it opened.
+	b.handleRPCEvent(Event{"type": "agent_start"})
+	b.mu.Lock()
+	marked = b.heartbeatRun
+	b.mu.Unlock()
+	if !marked {
+		t.Fatal("agent_start must not clear heartbeatRun before the run settles")
+	}
+
+	// No reply, no recovery: the banner must be suppressed for a heartbeat run.
+	if b.bannerNoReply(false, false) {
+		t.Error("banner must be suppressed for a heartbeat wake with no reply")
+	}
+
+	// Simulate the settle consuming the flag; a later user-initiated run with
+	// no reply banners normally again.
+	b.handleRPCEvent(Event{"type": "agent_settled"})
+	if !b.bannerNoReply(false, false) {
+		t.Error("after consume, a normal unanswered run must banner again")
+	}
+}
+
+// TestBannerNoReplyGates pins the banner condition directly: it fires only for
+// an unanswered, non-quiet-wake run with no recovery in flight.
+func TestBannerNoReplyGates(t *testing.T) {
+	b := bgBridge()
+
+	// No reply, not a quiet wake, no recovery → banner.
+	if !b.bannerNoReply(false, false) {
+		t.Error("unanswered run should banner")
+	}
+
+	// A delivered reply suppresses it.
+	b.setReplied(true)
+	if b.bannerNoReply(false, false) {
+		t.Error("replied run should not banner")
+	}
+	b.setReplied(false)
+
+	// Quiet wakes suppress it.
+	b.volunteered = true
+	if b.bannerNoReply(false, false) {
+		t.Error("volunteer run should not banner")
+	}
+	b.volunteered = false
+	b.reactionAckRun = true
+	if b.bannerNoReply(false, false) {
+		t.Error("reaction-ack run should not banner")
+	}
+	b.reactionAckRun = false
+	b.heartbeatRun = true
+	if b.bannerNoReply(false, false) {
+		t.Error("heartbeat run should not banner")
+	}
+	b.heartbeatRun = false
+
+	// A recovery/nudge in flight holds it.
+	if b.bannerNoReply(true, false) || b.bannerNoReply(false, true) {
+		t.Error("recovery or nudge in flight should hold the banner")
+	}
+}
+
 // TestToolRelayProcessHeartbeatInjectsPrompt: an idle agent receives the
 // long-running-process alarm as an injected prompt carrying the TRUE elapsed
 // seconds and the log tail, presence goes dnd thinking, and the relay answers

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -1229,3 +1229,102 @@ func TestToolRelayProcessCount(t *testing.T) {
 		t.Errorf("presence after relay = %q, want \"waiting on 3 processes\"", b.xmpp.presence)
 	}
 }
+
+// TestToolRelayProcessHeartbeatInjectsPrompt: an idle agent receives the
+// long-running-process alarm as an injected prompt carrying the TRUE elapsed
+// seconds and the log tail, presence goes dnd thinking, and the relay answers
+// ok so the extension's blocking select resolves.
+func TestToolRelayProcessHeartbeatInjectsPrompt(t *testing.T) {
+	var buf bytes.Buffer
+	b := bgBridge()
+	b.rpc = &RPCClient{stdin: &nopClose{buf: &buf}, mu: sync.Mutex{}}
+
+	b.handleToolRelay("r-hb", `{"action":"process_heartbeat","processes":[{"id":"p1","name":"gradle","command":"./gradlew assembleRelease","elapsedSecs":606,"tail":"BUILD SUCCESSFUL in 3m 12s\n"}]}`)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !strings.Contains(buf.String(), "\"value\": \"ok\"") && !strings.Contains(buf.String(), "\"value\":\"ok\"") {
+		if time.Now().After(deadline) {
+			t.Fatalf("no relay response within 2s (buf=%q)", buf.String())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Both the prompt and the relay ok land in the same stdin buffer (prompt
+	// first — fireHeartbeat runs before RespondUIRelay), so assert on the whole
+	// buffer rather than consuming a single line.
+	out := buf.String()
+	if !strings.Contains(out, "\"type\":\"prompt\"") {
+		t.Errorf("heartbeat did not prompt pi (buf=%q)", out)
+	}
+	if !strings.Contains(out, "process \\\"gradle\\\" has been running for 606 seconds now") {
+		t.Errorf("heartbeat prompt missing true elapsed time (buf=%q)", out)
+	}
+	if !strings.Contains(out, "BUILD SUCCESSFUL in 3m 12s") {
+		t.Errorf("heartbeat prompt missing log tail (buf=%q)", out)
+	}
+	if b.xmpp.show != "dnd" || b.xmpp.presence != "thinking…" {
+		t.Errorf("heartbeat presence = %q/%q, want dnd thinking", b.xmpp.show, b.xmpp.presence)
+	}
+}
+
+// TestToolRelayProcessHeartbeatQueuedWhileStreaming: a heartbeat arriving while
+// a run is in flight must NOT interrupt (no prompt), the relay still answers
+// ok, and the alarm is delivered on agent_settled via flushPendingHeartbeats.
+func TestToolRelayProcessHeartbeatQueuedWhileStreaming(t *testing.T) {
+	var buf bytes.Buffer
+	b := bgBridge()
+	b.rpc = &RPCClient{stdin: &nopClose{buf: &buf}, mu: sync.Mutex{}}
+	b.setStreaming(true) // a run is in flight
+
+	b.handleToolRelay("r-hb2", `{"action":"process_heartbeat","processes":[{"id":"p1","name":"install","command":"pnpm install","elapsedSecs":721,"tail":""}]}`)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for !strings.Contains(buf.String(), "\"value\": \"ok\"") && !strings.Contains(buf.String(), "\"value\":\"ok\"") {
+		if time.Now().After(deadline) {
+			t.Fatalf("no relay response within 2s (buf=%q)", buf.String())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Nothing may have been prompted while the run was in flight.
+	out := buf.String()
+	if strings.Contains(out, "\"type\": \"prompt\"") {
+		t.Error("heartbeat prompted pi mid-run; must be deferred")
+	}
+
+	// The run settles: the queue flushes into a prompt.
+	b.setStreaming(false)
+	b.flushPendingHeartbeats()
+	out = buf.String()
+	if !strings.Contains(out, "process \\\"install\\\" has been running for 721 seconds now") {
+		t.Errorf("queued heartbeat not flushed after settle (buf=%q)", out)
+	}
+	if !strings.Contains(out, "(no output yet)") {
+		t.Errorf("empty-tail heartbeat should say so (buf=%q)", out)
+	}
+}
+
+// TestFormatHeartbeat pins the multi-process batch form: several overdue
+// processes become ONE alarm with a section per process, so the agent is
+// woken once rather than once per process.
+func TestFormatHeartbeat(t *testing.T) {
+	b := bgBridge()
+	got := b.formatHeartbeat([]HeartbeatProcess{
+		{Name: "build", ElapsedSecs: 600, Tail: "one"},
+		{Name: "test", ElapsedSecs: 1, Tail: ""},
+	})
+	if !strings.Contains(got, "2 background processes have been running") {
+		t.Errorf("batch headline missing (got=%q)", got)
+	}
+	if !strings.Contains(got, "build — 600 seconds") || !strings.Contains(got, "test — 1 second") {
+		t.Errorf("per-process lines missing/plural wrong (got=%q)", got)
+	}
+	if !strings.Contains(got, "no output yet") {
+		t.Errorf("empty-tail placeholder missing (got=%q)", got)
+	}
+
+	// Empty input renders no alarm at all (callers guard on len>0 anyway).
+	if empty := b.formatHeartbeat(nil); empty != "" {
+		t.Errorf("formatHeartbeat(nil) = %q, want empty", empty)
+	}
+}

--- a/piext/xmpp-tools.ts
+++ b/piext/xmpp-tools.ts
@@ -116,6 +116,124 @@ export default function xmppTools(pi: ExtensionAPI) {
 		void refreshProcessCount();
 	});
 
+	// --- Long-running-process heartbeats ---
+	//
+	// While background processes run, pi-msg keeps the agent's presence dnd so
+	// it doesn't drift away — but a process that runs for hours is invisible
+	// once the agent has settled. Every HEARTBEAT_INTERVAL_MS this extension
+	// asks pi-msg to wake the idle agent with a status line + log tail for each
+	// live process that has been running for at least one full interval
+	// (elapsed computed from the manager's startTime, so the reported seconds
+	// are always the true value). The bridge decides when delivery is safe
+	// (never mid-run) and does the actual prompt injection; this side only
+	// gathers and relays.
+	const PROCESS_COMBINED_OUTPUT = "processes:request:combined_output";
+	const HEARTBEAT_INTERVAL_MS = Number(process.env.PI_MSG_PROCESS_HEARTBEAT_MS ?? 600_000);
+	const HEARTBEAT_TAIL_LINES = 40;
+
+	// queryProcesses asks the pi-processes manager for the full process list
+	// (same channel as queryProcessCount, but returns the entries).
+	function queryProcesses(): Promise<Array<Record<string, unknown>>> {
+		return new Promise((resolve) => {
+			let settled = false;
+			const done = (list: Array<Record<string, unknown>>) => {
+				if (!settled) {
+					settled = true;
+					resolve(list);
+				}
+			};
+			pi.events.emit(PROCESS_LIST, {
+				reply: (processes: unknown) => {
+					if (!Array.isArray(processes)) {
+						done([]);
+					return;
+				}
+				done(processes.filter((p) => p !== null && typeof p === "object") as Array<Record<string, unknown>>);
+			},
+			});
+			setTimeout(() => done([]), 500);
+		});
+	}
+
+	// fetchProcessTail pulls the tail of a process's combined output via the
+	// manager's synchronous query channel. Returns "" when there is no output.
+	function fetchProcessTail(id: string): Promise<string> {
+		return new Promise((resolve) => {
+			let settled = false;
+			const done = (text: string) => {
+				if (!settled) {
+					settled = true;
+					resolve(text);
+				}
+			};
+			pi.events.emit(PROCESS_COMBINED_OUTPUT, {
+				id,
+				tailLines: HEARTBEAT_TAIL_LINES,
+				reply: (lines: unknown) => {
+					if (!Array.isArray(lines)) {
+						done("");
+						return;
+					}
+					done(
+						lines
+							.map((l) =>
+								l !== null && typeof l === "object" && typeof (l as { text?: unknown }).text === "string"
+									? (l as { text: string }).text
+									: "",
+							)
+							.filter((t) => t.length > 0)
+							.join("\n"),
+					);
+				},
+			});
+			setTimeout(() => done(""), 500);
+		});
+	}
+
+	// heartbeatTick is the interval alarm: for every live process that has been
+	// running for at least one full interval, attach its name, true elapsed
+	// time and a log tail, and relay a single process_heartbeat — so the bridge
+	// wakes the (idle) agent once with everything at once, not once per process.
+	async function heartbeatTick() {
+		if (!ui) return;
+		try {
+			const processes = await queryProcesses();
+			const now = Date.now();
+			const overdue: Array<Record<string, unknown>> = [];
+			for (const p of processes) {
+				const status = String(p.status ?? "");
+				if (!LIVE_STATUSES.has(status)) continue;
+				const startTime = p.startTime;
+				const elapsedMs = typeof startTime === "number" ? now - startTime : 0;
+				if (elapsedMs < HEARTBEAT_INTERVAL_MS) continue;
+				const id = String(p.id ?? "");
+				if (!id) continue;
+				overdue.push({
+					id,
+					name: String(p.name ?? id),
+					command: String(p.command ?? ""),
+					elapsedSecs: Math.round(elapsedMs / 1000),
+					tail: await fetchProcessTail(id),
+				});
+			}
+			if (overdue.length === 0) return;
+			await relay("process_heartbeat", { processes: overdue });
+		} catch {
+			// Best-effort: a dropped heartbeat is just a missed status check.
+		}
+	}
+
+	// The heartbeat interval. Registered at session_start: setInterval is
+	// non-blocking, so it is safe under the rule that no relay/dialog may run
+	// synchronously in that hook.
+	let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+	function startHeartbeat() {
+		if (heartbeatTimer) return;
+		heartbeatTimer = setInterval(() => {
+			void heartbeatTick();
+		}, HEARTBEAT_INTERVAL_MS);
+	}
+
 	pi.on("session_start", (_event, ctx) => {
 		ui = ctx.ui as unknown as RelayUI;
 		// Deferred seed of the background-process count. This must NOT happen
@@ -130,6 +248,7 @@ export default function xmppTools(pi: ExtensionAPI) {
 		setTimeout(() => {
 			void refreshProcessCount();
 		}, 2000);
+		startHeartbeat();
 	});
 
 	// Inject the agent's identity ($PI_MSG_ACCOUNT) at the top of every system


### PR DESCRIPTION
## What

Once the agent settles, a background process that runs for hours is invisible — presence just says dnd "waiting on N processes" and the next natural turn may be long after the process finished. This adds a periodic heartbeat that **wakes the idle agent** with a status line + log tail for each long-running process, so an unexpected long run gets investigated promptly.

## How it works

- **Extension** (`piext/xmpp-tools.ts`): every `PI_MSG_PROCESS_HEARTBEAT_MS` (default 10 min) it queries the pi-processes manager for live processes and, for any running ≥ one full interval, relays a single `process_heartbeat` carrying name, **true elapsed seconds** (from the manager's `startTime`, not a fixed example) and a 40-line combined-output tail. Multiple overdue processes batch into ONE alarm (a section each) so the agent is woken once, not once per process.
- **Bridge** (`bridge.go`): formats Zack's phrasing — `[pi-msg: process X has been running for N seconds now. Here's the log tail: … If this is unexpected, determine what happened and act. If this is expected, reply with to: noop]` — and injects it as a prompt, routing any response to the owner. **While a run is in flight the alarm is queued (never interrupts an active turn) and flushed on agent_settled**, so it's deferred, never lost.

## Verification

- `go build ./...` ✓
- New Go tests: heartbeat injects a prompt with true elapsed seconds + tail ✓, heartbeat while streaming is queued + flushed on settle ✓, multi-process batching ✓; full suite green.
- Extension typechecks (tsc 5.9.3 vs pi's own `@earendil-works/pi-coding-agent` + `typebox` types).
- ~Battle Droid end-to-end test pending~ (see below).