### PR TITLE
feat: low-credit alerts — 402 DM + proactive credit watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Per-account fields:
 | `pingInterval` | no | `60s` | keepalive cadence (Go duration): XEP-0199 server ping + XEP-0410 MUC self-ping; `0` disables |
 | `reactions` | no | `false` | XEP-0444 emoji reactions on 1:1 owner messages: lifecycle → 👀 picked up / ✅ done / ⛔ aborted, and enables the agent-driven `send_reaction` tool (see [Agent tools](#agent-tools)) |
 | `avatar` | no | — | path to a local image (PNG/JPEG/GIF) published as the bot's XEP-0153 vCard profile picture on connect |
-| `creditWatch` | no | — | when set with a `minBelowUsd` floor, reports the remaining OpenRouter credit balance every time the agent runs `/new`. e.g. `{ "creditWatch": { "minBelowUsd": 2 } }`. Only active when pi's auth file (`<config-dir>/auth.json`) holds an `openrouter` api key; otherwise it's skipped. The remaining credit is shown on every `/new`; it's flagged as low when it drops below the floor |
+| `creditWatch` | no | — | low-credit protection with a `minBelowUsd` floor. Reports the remaining OpenRouter balance after every `/new`, and a proactive watcher probes the balance hourly and DMs the owner when it drops below the floor (re-warns at most every 6h while still below). A model run that dies on an OpenRouter out-of-credits error (HTTP 402) is also reported to the owner directly instead of the generic "done (no reply)". e.g. `{ "creditWatch": { "minBelowUsd": 2 } }`. Only active when pi's auth file (`<config-dir>/auth.json`) holds an `openrouter` api key; otherwise it's skipped |
 
 Multiple accounts: add more keys under `accounts`; `default` is used unless you set
 `PI_MSG_ACCOUNT=<name>`. In 1:1 mode only the `owner` JID may drive the agent.

--- a/bridge.go
+++ b/bridge.go
@@ -21,6 +21,15 @@ import (
 // it (~30s), so the typing indicator stays lit while the agent works.
 const typingRefresh = 20 * time.Second
 
+// creditCheckInterval is how often the proactive low-credit watcher probes the
+// OpenRouter balance (see maybeCheckCredits).
+const creditCheckInterval = time.Hour
+
+// creditReWarnDelay is the minimum gap between low-credit DMs to the owner
+// while the balance stays below the floor, so a dry spell nags without
+// spamming.
+const creditReWarnDelay = 6 * time.Hour
+
 // Bridge wires an XMPP connection to a `pi --mode rpc` child: owner chat
 // becomes pi commands, and pi's events become chat replies / presence /
 // typing.
@@ -97,6 +106,10 @@ type Bridge struct {
 	awayAnnounced  bool      // the away transition has been announced this idle period
 	lastAwayStatus string    // the last pithy activity shown while away (skip repeats across periods)
 	bgProcesses    int       // background processes pi has running (relayed by the pi-processes extension)
+
+	// Periodic low-credit watcher state (see maybeCheckCredits).
+	lastCreditProbe time.Time // when the balance endpoint was last hit
+	lastCreditWarn  time.Time // when the owner was last DMed about low credit
 
 	lifecycleReactTo string // snapshot of reactTo at run start, for lifecycle auto-reacts
 	lifecycleReactID string // snapshot of reactID at run start; never overwritten by deliverReply
@@ -453,6 +466,17 @@ func (b *Bridge) handleRPCEvent(ev Event) {
 		msg := ev.Obj("message")
 		if msg == nil || msg.Str("role") != "assistant" {
 			return
+		}
+		// A run that died on OpenRouter credits (HTTP 402) has no text to
+		// deliver — without this hook the owner got the generic "done (no
+		// reply)" nudge and no hint WHY. DM them the failure instead (see
+		// creditFailAlert), and clear the in-run recovery bookkeeping so
+		// settle can't fire a tail-retry / unanswered-hint prompt (which
+		// would just 402 again).
+		if msg.Str("stopReason") == "error" {
+			if b.creditFailAlert(msg.Str("errorMessage")) {
+				return // consumed: owner alerted, run marked replied
+			}
 		}
 		// Record whether THIS message carried text before delivering it: at
 		// settle, only the last message's answer matters, and a run whose final
@@ -2454,7 +2478,100 @@ func (b *Bridge) reportCreditIfWatched() {
 	if remaining >= b.acct.MinCreditUsd {
 		return
 	}
-	b.reply(fmt.Sprintf("⚠️ OpenRouter credit: $%.2f remaining — below your $%.2f floor, reload soon", remaining, b.acct.MinCreditUsd))
+	b.reply(lowCreditText(remaining, b.acct.MinCreditUsd))
+}
+
+// maybeCheckCredits is the proactive low-credit watcher, called from idleTick.
+// Every creditCheckInterval it probes the OpenRouter balance and DMs the owner
+// when it sits below the creditWatch floor. This closes the gap that bit Zach:
+// reportCreditIfWatched only fires on /new, so a balance that dropped below the
+// floor mid-session was never reported — until a 402 killed a run outright.
+// Re-warns at most once per creditReWarnDelay while still below the floor.
+func (b *Bridge) maybeCheckCredits() {
+	if b.acct.MinCreditUsd <= 0 {
+		return
+	}
+	key := openRouterKey()
+	if key == "" {
+		return
+	}
+	b.mu.Lock()
+	if time.Since(b.lastCreditProbe) < creditCheckInterval {
+		b.mu.Unlock()
+		return
+	}
+	b.lastCreditProbe = time.Now()
+	b.mu.Unlock()
+
+	total, used, err := openRouterCredits(key)
+	if err != nil {
+		b.log("warning", "periodic credit check failed: "+err.Error())
+		return
+	}
+	remaining := total - used
+	if remaining >= b.acct.MinCreditUsd {
+		return
+	}
+	b.mu.Lock()
+	rearm := time.Since(b.lastCreditWarn) >= creditReWarnDelay
+	if rearm {
+		b.lastCreditWarn = time.Now()
+	}
+	b.mu.Unlock()
+	if !rearm {
+		return
+	}
+	b.reply(lowCreditText(remaining, b.acct.MinCreditUsd))
+}
+
+// lowCreditText renders the below-floor credit alert shared by the /new report
+// and the periodic watcher.
+func lowCreditText(remaining, floor float64) string {
+	return fmt.Sprintf("⚠️ OpenRouter credit: $%.2f remaining — below your $%.2f floor, reload soon", remaining, floor)
+}
+
+// isCreditError reports whether a model-run error is an OpenRouter
+// out-of-credits failure (HTTP 402). pi relays the provider error verbatim in
+// the errored assistant message's errorMessage, so the 402 body text —
+// "requires more credits", "can only afford N tokens", "insufficient" — is
+// what we match.
+func isCreditError(errMsg string) bool {
+	s := strings.ToLower(errMsg)
+	return strings.Contains(s, "402") ||
+		strings.Contains(s, "more credits") ||
+		strings.Contains(s, "out of credits") ||
+		strings.Contains(s, "insufficient")
+}
+
+// creditFailAlert handles a model run that died to an OpenRouter credit
+// failure. Without this hook the run ends with no message and the owner gets
+// the generic "done (no reply)" nudge — exactly what Zach saw when a 402 hit
+// mid-work. The alert DMs the owner directly, marks the run as replied so the
+// no-reply nudge is suppressed, and returns true. Non-credit errors return
+// false and keep the existing behavior.
+func (b *Bridge) creditFailAlert(errMsg string) bool {
+	if !isCreditError(errMsg) {
+		return false
+	}
+	b.log("warning", "model run failed on OpenRouter credits: "+errMsg)
+	b.reply("⚠️ Out of OpenRouter credits — the run couldn't proceed. Top up at https://openrouter.ai/settings/credits (" + shortError(errMsg) + ")")
+	// Mark replied so the "done (no reply)" nudge is suppressed, and clear the
+	// in-run bookkeeping so settle can't fire a tail-retry or unanswered-hint
+	// prompt — a recovery prompt would just hit the same 402 again.
+	b.setReplied(true)
+	b.resetTailTracking()
+	b.markHintPending()
+	return true
+}
+
+// shortError trims a provider error string to one readable line.
+func shortError(s string) string {
+	s = strings.Join(strings.Fields(s), " ")
+	r := []rune(s)
+	if len(r) <= 160 {
+		return s
+	}
+	return string(r[:157]) + "…"
 }
 
 // openRouterKey returns pi's configured OpenRouter API key from the auth file
@@ -2926,6 +3043,8 @@ func (b *Bridge) idleWatcher(ctx context.Context) {
 // once per idle period, once the agent has been idle past idleAwayTimeout.
 // Split out from idleWatcher so it's callable directly from tests.
 func (b *Bridge) idleTick() {
+	b.maybeCheckCredits()
+
 	b.mu.Lock()
 	idle := !b.idleSince.IsZero()
 	elapsed := time.Since(b.idleSince)

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -5,9 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -68,9 +71,9 @@ func TestBareBangIsAbort(t *testing.T) {
 		in   string
 		name string
 	}{
-		{"!", "abort"},   // lone bang → handleCommand maps to abort
-		{"!!", "!"},      // two bangs → name "!", falls through as text
-		{"! abort", ""},  // space after bang → empty name, falls through
+		{"!", "abort"},  // lone bang → handleCommand maps to abort
+		{"!!", "!"},     // two bangs → name "!", falls through as text
+		{"! abort", ""}, // space after bang → empty name, falls through
 		{"!abort", "abort"},
 	}
 	for _, c := range cases {
@@ -1227,5 +1230,171 @@ func TestToolRelayProcessCount(t *testing.T) {
 	}
 	if b.xmpp.presence != "waiting on 3 processes" {
 		t.Errorf("presence after relay = %q, want \"waiting on 3 processes\"", b.xmpp.presence)
+	}
+}
+func TestIsCreditError(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		// The real OpenRouter 402 body Zach pasted.
+		{`402: {"message":"This request requires more credits, or fewer max_tokens. You requested up to 384000 tokens, but can only afford 99218."}`, true},
+		{"This request requires more credits, or fewer max_tokens.", true},
+		{"402 insufficient balance", true},
+		{"you are out of credits", true},
+		{"Request timed out.", false},
+		{"529 overloaded_error: Overloaded", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := isCreditError(c.in); got != c.want {
+			t.Errorf("isCreditError(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestLowCreditText(t *testing.T) {
+	if got := lowCreditText(3.5, 5); got != "⚠️ OpenRouter credit: $3.50 remaining — below your $5.00 floor, reload soon" {
+		t.Errorf("lowCreditText = %q", got)
+	}
+}
+
+func TestShortError(t *testing.T) {
+	if got := shortError("  a\n\nb  "); got != "a b" {
+		t.Errorf("shortError collapsed = %q, want 'a b'", got)
+	}
+	long := strings.Repeat("x", 300)
+	if got := shortError(long); len([]rune(got)) != 158 { // 157 + ellipsis
+		t.Errorf("shortError(long) len = %d, want 158", len([]rune(got)))
+	}
+}
+
+// A message_end carrying an errored assistant message with the OpenRouter 402
+// body must DM the owner (marked replied) instead of falling through to the
+// "done (no reply)" nudge.
+func TestCreditFailAlertOnMessageEnd(t *testing.T) {
+	b := roomBridge()
+	b.xmpp = NewXMPPBridge(b.acct, func(InboundMessage) {}, func(_, _ string) {})
+	b.acct.MinCreditUsd = 2
+	b.setReplied(false)
+
+	ev := Event{
+		"type": "message_end",
+		"message": map[string]any{
+			"role":         "assistant",
+			"content":      []any{},
+			"stopReason":   "error",
+			"errorMessage": `402: {"message":"This request requires more credits, or fewer max_tokens."}`,
+		},
+	}
+	b.handleRPCEvent(ev)
+	if !b.replied() {
+		t.Error("credit-failed run should be marked replied so the no-reply nudge is suppressed")
+	}
+}
+
+// Non-credit run failures (timeout, overloaded) keep the existing behavior:
+// not marked replied, so the agent_settled nudge still applies.
+func TestNonCreditErrorUnchanged(t *testing.T) {
+	b := roomBridge()
+	b.xmpp = NewXMPPBridge(b.acct, func(InboundMessage) {}, func(_, _ string) {})
+	b.setReplied(false)
+
+	ev := Event{
+		"type": "message_end",
+		"message": map[string]any{
+			"role":         "assistant",
+			"content":      []any{},
+			"stopReason":   "error",
+			"errorMessage": "Request timed out.",
+		},
+	}
+	b.handleRPCEvent(ev)
+	if b.replied() {
+		t.Error("non-credit error must not mark the run replied; the no-reply nudge should still apply")
+	}
+}
+
+// maybeCheckCredits probes at most once per creditCheckInterval, DMs the owner
+// when the balance is below the floor, and re-warns at most once per
+// creditReWarnDelay while still below.
+func TestMaybeCheckCredits(t *testing.T) {
+	// Point openRouterKey at a temp auth file.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{"openrouter":{"key":"sk-or-test"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PI_CODING_AGENT_DIR", dir)
+
+	// Stub the credits endpoint, counting hits. remaining is mutable so the
+	// same server can answer both below- and above-floor states.
+	var (
+		hitsMu    sync.Mutex
+		hits      int
+		remaining = 2.0 // below the $5 floor
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hitsMu.Lock()
+		hits++
+		hitsMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, fmt.Sprintf(`{"data":{"total_credits":10,"total_usage":%v}}`, 10-remaining))
+	}))
+	defer srv.Close()
+	orig := creditEndpoint
+	creditEndpoint = srv.URL
+	defer func() { creditEndpoint = orig }()
+
+	b := roomBridge()
+	b.xmpp = NewXMPPBridge(b.acct, func(InboundMessage) {}, func(_, _ string) {})
+	b.acct.MinCreditUsd = 5
+
+	b.maybeCheckCredits()
+	if b.lastCreditWarn.IsZero() {
+		t.Fatal("below-floor balance should warn the owner on the first probe")
+	}
+	warn1 := b.lastCreditWarn
+
+	// Immediate re-call: interval gate suppresses another probe/warn.
+	b.maybeCheckCredits()
+	if !b.lastCreditWarn.Equal(warn1) {
+		t.Error("re-warn fired inside creditCheckInterval")
+	}
+	b.mu.Lock()
+	hitsNow := hits
+	b.mu.Unlock()
+	if hitsNow != 1 {
+		t.Errorf("endpoint hit %d times in one interval, want 1", hitsNow)
+	}
+
+	// Above the floor: a fresh probe must not warn.
+	remaining = 8                   // $8 remaining > $5 floor
+	b.lastCreditProbe = time.Time{} // force a fresh probe
+	b.lastCreditWarn = time.Time{}
+	b.maybeCheckCredits()
+	if !b.lastCreditWarn.IsZero() {
+		t.Error("above-floor balance must not warn")
+	}
+}
+
+// Accounts without a creditWatch floor must never probe the endpoint at all.
+func TestMaybeCheckCreditsNoFloor(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{"openrouter":{"key":"sk-or-test"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PI_CODING_AGENT_DIR", dir)
+
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hits++ }))
+	defer srv.Close()
+	orig := creditEndpoint
+	creditEndpoint = srv.URL
+	defer func() { creditEndpoint = orig }()
+
+	b := roomBridge() // MinCreditUsd = 0
+	b.maybeCheckCredits()
+	if hits != 0 {
+		t.Errorf("endpoint hit %d times with no floor configured, want 0", hits)
 	}
 }


### PR DESCRIPTION
## What

Zach hit two low-credit blind spots when OpenRouter ran dry:

1. **402 → "done (no reply)", no explanation.** A model run that died on
   `402: This request requires more credits...` left an errored assistant
   message with no text, so the bridge delivered nothing and the owner got
   the generic no-reply nudge. The bridge now detects the credit failure in
   `message_end` (`stopReason: "error"` + credit-matching `errorMessage`)
   and DMs the owner the failure with the top-up link, marked replied so the
   nudge is suppressed. Non-credit errors (timeout, overloaded) are unchanged.

2. **`creditWatch` only fired on `/new`.** The floor was checked solely when
   the agent ran `/new`, so a balance dropping below the floor mid-session
   was never reported. A proactive watcher now runs from the idle tick: it
   probes the OpenRouter balance hourly and DMs the owner when below the
   floor, re-warning at most every 6h while still below. Below-floor balance
   is also reported within the first probe after a restart.

## Tests

- `TestIsCreditError` / `TestLowCreditText` / `TestShortError` — pure matcher + formatting
- `TestCreditFailAlertOnMessageEnd` / `TestNonCreditErrorUnchanged` — 402 path marked replied; non-credit errors keep old behavior
- `TestMaybeCheckCredits` / `TestMaybeCheckCreditsNoFloor` — hourly gate, single probe per interval, below-floor warn, above-floor silence, no floor = no probe

`go build`, `go vet`, `go test ./...` all green.