### PR TITLE
flake: declare the pi version this bridge requires

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,11 @@
         "x86_64-linux"
         "aarch64-linux"
       ];
+      # The pi-coding-agent version this bridge requires at runtime (spawned as
+      # `pi --mode rpc`). pi-msg targets pi 0.84.0+ (see README); /abort needs
+      # `clear_queue`, added in 0.84.4. Single source of truth — deployments
+      # read it via passthru instead of pinning their own copy.
+      piAgentVersion = "0.84.4";
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f (import nixpkgs { inherit system; }));
     in
     {
@@ -31,6 +36,7 @@
             mainProgram = "pi-msg";
             license = pkgs.lib.licenses.mit;
           };
+          passthru.piAgentVersion = piAgentVersion;
         };
       });
 


### PR DESCRIPTION
pi-msg spawns `pi --mode rpc` but pinned no pi version. The deployment (zachpmanson/nix) hardcoded 0.81.1 — below pi-msg's declared floor of 0.84.0+ (README: /abort needs `clear_queue`, added 0.84.4).

This adds `passthru.piAgentVersion = "0.84.4"` to the `pi-msg` package so the flake is the single source of truth; the nix repo will consume it (separate PR) instead of maintaining its own copy. Verified: `nix flake check` ✓, passthru reads `"0.84.4"` ✓.