### PR TITLE
fix: presence label mutters until a routing line proves a reply

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -387,7 +387,7 @@ func (b *Bridge) shutdown(reason string) {
 // mean "busy" (see docs): the typing indicator = "a message is arriving right
 // now" (lit only while assistant text streams); presence <show> = availability
 // (dnd while a run is in flight, available when idle); presence <status> = the
-// current activity label (thinking / running a tool / replying / retrying).
+// current activity label (thinking / running a tool / muttering / replying / retrying).
 func (b *Bridge) handleRPCEvent(ev Event) {
 	switch ev.Type() {
 	case "agent_start":
@@ -2697,7 +2697,19 @@ func (b *Bridge) handleStreamDelta(ev Event) {
 	case "thinking_start":
 		b.xmpp.SetPresence("dnd", "thinking…")
 	case "text_start":
-		b.xmpp.SetPresence("dnd", "replying…")
+		// Presence label: a room-mode stream is most often inter-tool
+		// commentary that never gains a "to:" line and is never delivered,
+		// so it starts as "muttering…" and only upgrades to "replying…"
+		// once a routing line proves a real reply (see streamTypingDelta).
+		// The typing indicator is the "message actually about to be routed"
+		// signal (issue #44), so a muttering label cannot be mistaken for a
+		// pending reply. A pure 1:1 account has no routing contract — every
+		// streamed word IS the reply, so it stays "replying…".
+		if b.acct.RoomMode() {
+			b.xmpp.SetPresence("dnd", "muttering…")
+		} else {
+			b.xmpp.SetPresence("dnd", "replying…")
+		}
 		// In a room-mode account the reply's destination is only known once
 		// its "to: <jid>" routing line streams in, so typing is withheld
 		// until then rather than lit speculatively on the owner (issue #44).
@@ -2812,26 +2824,35 @@ func (b *Bridge) streamTypingDelta(delta string) {
 		return
 	}
 	b.typingStream += delta
-	target, decided := streamTypingTarget(b.typingStream, b.xmpp)
+	target, decided, delivers := streamTypingTarget(b.typingStream, b.xmpp)
 	if !decided {
 		return
 	}
 	b.typingRoutingDone = true
 	if target == "" {
 		b.stopTyping()
-		return
+	} else {
+		b.startTypingTo(target)
 	}
-	b.startTypingTo(target)
+	// A completed routing line that will actually emit a stanza upgrades the
+	// label from "muttering…" to "replying…"; a line that sends nothing
+	// (noop, an unknown stanza id, a blocked target) keeps the composer dark
+	// and the label honest as muttering.
+	if delivers {
+		b.xmpp.SetPresence("dnd", "replying…")
+	}
 }
 
 // streamTypingTarget inspects the partial streamed text for a completed routing
-// line and maps it to a typing recipient. It returns (target, true) once a
-// routing line resolves — target "" means the composer must stay dark — or
-// ("", false) while the text is still streaming and no complete line exists.
-// Only a destination that classifies as a 1:1 chat (the owner or a plain
-// occupant) earns an indicator; a room, "noop", or blocked target never lights
-// the owner's bubble.
-func streamTypingTarget(buf string, xm *XMPPBridge) (target string, decided bool) {
+// line and maps it to a typing recipient. It returns (target, decided,
+// delivers): decided is true once a routing line resolves, target is the 1:1
+// recipient whose composer should light ("" means the composer must stay dark),
+// and delivers reports whether that line will actually emit a stanza (a 1:1 or
+// room reply) as opposed to sending nothing — a noop, an unknown stanza id, or
+// a blocked target never delivers, exactly as their composer stays dark. The
+// delivers flag is what upgrades the presence label from "muttering…" to
+// "replying…" (see streamTypingDelta).
+func streamTypingTarget(buf string, xm *XMPPBridge) (target string, decided bool, delivers bool) {
 	hasEnd := strings.HasSuffix(buf, "\n")
 	lines := strings.Split(buf, "\n")
 	end := len(lines)
@@ -2846,22 +2867,27 @@ func streamTypingTarget(buf string, xm *XMPPBridge) (target string, decided bool
 			continue
 		}
 		if strings.EqualFold(dest, destNoopName) {
-			return "", true
+			return "", true, false
 		}
 		// A stanza-id route lights the composer only if the id resolves; an
-		// unknown id is a routing failure, and a failure never types.
+		// unknown id is a routing failure, and a failure never types or
+		// delivers.
 		if replyTo != "" {
 			dest = xm.lookupMessage(replyTo)
 			if dest == "" {
-				return "", true
+				return "", true, false
 			}
 		}
-		if xm.classifyDest(dest) == destUser {
-			return bareJid(dest), true
+		switch xm.classifyDest(dest) {
+		case destUser:
+			return bareJid(dest), true, true
+		case destRoom:
+			return "", true, true // a room reply delivers, but never lights a 1:1 composer
+		default: // blocked or otherwise not an allowed chat
+			return "", true, false
 		}
-		return "", true // room, blocked, or otherwise not a 1:1 chat
 	}
-	return "", false
+	return "", false, false
 }
 
 // stopTyping is unconditional so a running indicator can always be cleared

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -216,6 +216,8 @@ func TestClassifyDest(t *testing.T) {
 // indicator is withheld while the reply is still streaming / has not yet
 // written a routing line, and once a completed "to:" line appears it points at
 // that line's 1:1 recipient — or stays dark for a room, noop, or blocked target.
+// delivers reports whether that line will emit a stanza (the presence-label
+// upgrade from "muttering…" to "replying…").
 func TestStreamTypingTarget(t *testing.T) {
 	x := NewXMPPBridge(
 		ResolvedAccount{Rooms: []string{"team@muc.x"}, Owner: "zach@x"},
@@ -223,32 +225,35 @@ func TestStreamTypingTarget(t *testing.T) {
 	)
 	x.occupants["team@muc.x"] = map[string]string{"alice": "alice@x"}
 	cases := []struct {
-		buf     string
-		target  string
-		decided bool
+		buf      string
+		target   string
+		decided  bool
+		delivers bool
 	}{
 		// Not yet a complete routing line → keep waiting.
-		{"", "", false},
-		{"to:", "", false},
-		{"to: zach", "", false},
-		{"to: zach@x", "", false},
-		// Owner 1:1 → indicator on the owner.
-		{"to: zach@x\n", "zach@x", true},
-		{"to: zach@x/phone\n", "zach@x", true},
-		// Known occupant → indicator on the occupant.
-		{"to: alice@x\n", "alice@x", true},
+		{"", "", false, false},
+		{"to:", "", false, false},
+		{"to: zach", "", false, false},
+		{"to: zach@x", "", false, false},
+		// Owner 1:1 → indicator on the owner, delivers.
+		{"to: zach@x\n", "zach@x", true, true},
+		{"to: zach@x/phone\n", "zach@x", true, true},
+		// Known occupant → indicator on the occupant, delivers.
+		{"to: alice@x\n", "alice@x", true, true},
 		// A leading non-routing line is skipped; the routing still resolves.
-		{"sure\nto: zach@x\n", "zach@x", true},
-		// Room, noop, and unknown targets never light the owner's bubble.
-		{"to: team@muc.x\n", "", true},
-		{"to: noop\n", "", true},
-		{"to: stranger@x\n", "", true},
+		{"sure\nto: zach@x\n", "zach@x", true, true},
+		// Room deliveries never light the owner's bubble but DO deliver.
+		{"to: team@muc.x\n", "", true, true},
+		// Noop and unknown targets send nothing and never light the bubble.
+		{"to: noop\n", "", true, false},
+		{"to: stranger@x\n", "", true, false},
+		{"to: zach@x\ncommentary only", "zach@x", true, true},
 	}
 	for _, c := range cases {
-		got, decided := streamTypingTarget(c.buf, x)
-		if got != c.target || decided != c.decided {
-			t.Errorf("streamTypingTarget(%q) = (%q,%v), want (%q,%v)",
-				c.buf, got, decided, c.target, c.decided)
+		got, decided, delivers := streamTypingTarget(c.buf, x)
+		if got != c.target || decided != c.decided || delivers != c.delivers {
+			t.Errorf("streamTypingTarget(%q) = (%q,%v,%v), want (%q,%v,%v)",
+				c.buf, got, decided, delivers, c.target, c.decided, c.delivers)
 		}
 	}
 }
@@ -1048,6 +1053,11 @@ func TestStreamDeltaContractRoomMode(t *testing.T) {
 	if b.typingTo != "" {
 		t.Errorf("room-mode text_start typing target = %q, want empty (route unknown)", b.typingTo)
 	}
+	// Until a routing line proves a real reply, the stream reads as
+	// inter-tool commentary: label it muttering, not replying.
+	if b.xmpp.presence != "muttering…" {
+		t.Errorf("room-mode text_start presence = %q, want muttering…", b.xmpp.presence)
+	}
 
 	// The routing line arrives split across deltas, as it does on the wire.
 	for _, d := range []string{"to: ", "zach", "@x\n", "hi"} {
@@ -1056,10 +1066,41 @@ func TestStreamDeltaContractRoomMode(t *testing.T) {
 	if b.typingTo != "zach@x" {
 		t.Errorf("room-mode typing target = %q, want zach@x", b.typingTo)
 	}
+	// The routing line resolves to a real delivery: the label upgrades to
+	// replying, matching the lit composer.
+	if b.xmpp.presence != "replying…" {
+		t.Errorf("room-mode routed presence = %q, want replying…", b.xmpp.presence)
+	}
 
 	b.handleStreamDelta(streamDelta(map[string]any{"type": "text_end"}))
 	if b.typingTo != "" {
 		t.Errorf("room-mode text_end typing target = %q, want empty", b.typingTo)
+	}
+}
+
+// TestStreamDeltaCommentaryStaysMuttering pins that a stream carrying no
+// routing line — inter-tool commentary that will never be delivered — keeps
+// the "muttering…" label for the whole stream, and that a "to: noop" route
+// (deliberate silence, nothing sent) does not upgrade it either.
+func TestStreamDeltaCommentaryStaysMuttering(t *testing.T) {
+	b := newTestBridge(ResolvedAccount{Owner: "zach@x", Rooms: []string{"team@muc.x"}})
+
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "thinking_start"}))
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "text_start"}))
+	for _, d := range []string{"let me ", "check the ", "file\n", "done"} {
+		b.handleStreamDelta(streamDelta(map[string]any{"type": "text_delta", "delta": d}))
+	}
+	if b.xmpp.presence != "muttering…" {
+		t.Errorf("commentary stream presence = %q, want muttering…", b.xmpp.presence)
+	}
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "text_end"}))
+
+	// A deliberate-silence route resolves but delivers nothing: still muttering.
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "text_start"}))
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "text_delta", "delta": "to: noop\n"}))
+	b.handleStreamDelta(streamDelta(map[string]any{"type": "text_end"}))
+	if b.xmpp.presence != "muttering…" {
+		t.Errorf("noop stream presence = %q, want muttering…", b.xmpp.presence)
 	}
 }
 

--- a/reply_test.go
+++ b/reply_test.go
@@ -191,19 +191,21 @@ func TestStreamTypingTargetStanzaID(t *testing.T) {
 	x.recordMessage(roomMsg, "team@muc.x/alice")
 
 	// A 1:1 message resolves to the owner, so the composer lights up.
-	target, decided := streamTypingTarget("to: "+ownerMsg+"\n", x)
-	if !decided || target != "zach@x" {
-		t.Errorf("owner id = (%q,%v), want (\"zach@x\",true)", target, decided)
+	target, decided, delivers := streamTypingTarget("to: "+ownerMsg+"\n", x)
+	if !decided || target != "zach@x" || !delivers {
+		t.Errorf("owner id = (%q,%v,%v), want (\"zach@x\",true,true)", target, decided, delivers)
 	}
-	// A room message is not a 1:1 chat, so the composer stays dark.
-	target, decided = streamTypingTarget("to: "+roomMsg+"\n", x)
-	if !decided || target != "" {
-		t.Errorf("room id = (%q,%v), want (\"\",true)", target, decided)
+	// A room message is not a 1:1 chat, so the composer stays dark — but it
+	// still delivers, so the label upgrades to replying.
+	target, decided, delivers = streamTypingTarget("to: "+roomMsg+"\n", x)
+	if !decided || target != "" || !delivers {
+		t.Errorf("room id = (%q,%v,%v), want (\"\",true,true)", target, decided, delivers)
 	}
-	// An unknown id is a routing failure, and a failure never types.
-	target, decided = streamTypingTarget("to: ffffffff-ffff-ffff-ffff-ffffffffffff\n", x)
-	if !decided || target != "" {
-		t.Errorf("unknown id = (%q,%v), want (\"\",true)", target, decided)
+	// An unknown id is a routing failure, and a failure never types or
+	// delivers.
+	target, decided, delivers = streamTypingTarget("to: ffffffff-ffff-ffff-ffff-ffffffffffff\n", x)
+	if !decided || target != "" || delivers {
+		t.Errorf("unknown id = (%q,%v,%v), want (\"\",true,false)", target, decided, delivers)
 	}
 }
 


### PR DESCRIPTION
## Problem
The XMPP presence status label shows **"replying…"** from the moment any
assistant text starts streaming — including inter-tool commentary that never
gains a `to:` line and is never delivered (the "text before the first to:"
/ "no routing line" rejects in `deliverReply`). Zach watches the status and it
reads as a pending reply that never arrives.

## Fix
The typing indicator (issue #44) is the authoritative "message actually about
to be routed" signal — it only lights once a routing line streams in, and only
toward the real 1:1 recipient. So:

- **`text_start`** (room-mode accounts): label the stream **"muttering…"** —
  destination unknown, most streams are commentary.
- **Routing line resolves** to a route that will emit a stanza (owner/occupant
  1:1 **or** a room reply): upgrade to **"replying…"**.
- Routes that send nothing — `to: noop`, an unknown stanza-id, a blocked
  target — stay **"muttering…"**, matching their dark composer.
- **1:1 accounts** (no routing contract; every streamed word is the reply):
  unchanged, still **"replying…"** at `text_start`.

`streamTypingTarget` now returns a third `delivers` flag so the label upgrade
tracks the delivery decision, not just whether the composer lights.

## Tests
- `TestStreamDeltaContractRoomMode`: asserts `muttering…` at `text_start` and
  the upgrade to `replying…` once `to: zach@x` resolves.
- `TestStreamDeltaCommentaryStaysMuttering`: new — commentary-only stream and
  a `to: noop` route both keep `muttering…`.
- `TestStreamTypingTarget` / `TestStreamTypingTargetStanzaID`: extended for the
  `delivers` flag (room delivers; noop/unknown/stanza-id don't).