### PR TITLE
fix(xmpp): case-insensitive own-echo filter with dispatch backstop (#29)

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -775,6 +775,15 @@ func (b *Bridge) classify(m InboundMessage) (roomAction, string) {
 // trigger; a non-owner addressing the bot by name → untrusted-commentary
 // trigger; anything else → buffered ambient (no turn).
 func (b *Bridge) handleRoom(m InboundMessage) {
+	// Defence in depth (#29): the transport echo filter in dispatchRoom should
+	// already have dropped our own echo (case-insensitively). If one still
+	// arrives here, the transport guard missed — drop it rather than let it
+	// re-enter classify and prompt ourselves. Firing this guard logs loudly
+	// because it means the transport-level filter is broken.
+	if m.Nick != "" && b.xmpp != nil && strings.EqualFold(m.Nick, b.xmpp.ownNick(m.Room)) {
+		b.log("warning", fmt.Sprintf("own-echo reached dispatch despite transport guard (nick %q in %s); dropping", m.Nick, m.Room))
+		return
+	}
 	action, body := b.classify(m)
 	// Cascade bound (#23): an owner message resets the budget; agent-to-agent
 	// turns spend it. When exhausted, the trigger degrades to ambient so the

--- a/muc_test.go
+++ b/muc_test.go
@@ -492,3 +492,29 @@ func TestHandleIssuesBroadcastAndEnumeration(t *testing.T) {
 		t.Errorf("unknown=%v self=%q, want [zbeltino] and no self-tag", unknown, self)
 	}
 }
+
+// TestHandleRoomDropsOwnEcho is defence in depth (#29): even if the transport
+// echo filter in dispatchRoom misses, a room message whose sender nick matches
+// our own must be dropped at dispatch — not re-enter classify (where a
+// self-addressed body would dispatch as commentary and prompt ourselves).
+func TestHandleRoomDropsOwnEcho(t *testing.T) {
+	b := roomBridge()
+	b.xmpp = &XMPPBridge{acct: ResolvedAccount{Nick: "pi"}, selfNick: map[string]string{"team@muc.x.com": "pi"}}
+
+	// Own-echo with a body that would otherwise be ambient: must not buffer.
+	b.handleRoom(InboundMessage{Body: "just chatting", Nick: "PI", Room: "team@muc.x.com"})
+	if got := b.drainAmbient(); got != "" {
+		t.Fatalf("own-echo buffered as ambient: %q", got)
+	}
+	// Own-echo addressed to our own trigger: must not dispatch as commentary
+	// (without the guard this hits dispatchCommentary and prompts ourselves).
+	b.handleRoom(InboundMessage{Body: "pi: status?", Nick: "pI", Room: "team@muc.x.com"})
+	if got := b.drainAmbient(); got != "" {
+		t.Fatalf("own-echo leaked to dispatch: %q", got)
+	}
+	// Non-own nick still flows: ambient chatter buffers as usual.
+	b.handleRoom(InboundMessage{Body: "just chatting", Nick: "peppy", Room: "team@muc.x.com"})
+	if got := b.drainAmbient(); !strings.Contains(got, "peppy: just chatting") {
+		t.Fatalf("other occupant's ambient message not buffered: %q", got)
+	}
+}

--- a/xmpp.go
+++ b/xmpp.go
@@ -1020,7 +1020,11 @@ func (b *XMPPBridge) dispatchRoom(m incomingMsg) {
 	if nick == "" {
 		return // room-level stanza (e.g. subject with no occupant)
 	}
-	if nick == b.ownNick(room) {
+	// Own-echo guard — case-insensitive (#29): XMPP nick matching is case-folded
+	// in principle, so a server echoing a differently-cased resource must not
+	// defeat the filter (a miss lets our own message re-enter classify and
+	// prompt ourselves).
+	if strings.EqualFold(nick, b.ownNick(room)) {
 		return // our own echo
 	}
 	if m.delay {

--- a/xmpp_test.go
+++ b/xmpp_test.go
@@ -575,3 +575,39 @@ func TestPresenceChildrenMarshal(t *testing.T) {
 		}
 	}
 }
+
+// TestDispatchRoomOwnEchoCaseInsensitive verifies the MUC own-echo filter drops
+// messages from our own nick even when the server echoes a differently-cased
+// resource (XMPP nick matching is case-folded; a case-sensitive compare was
+// the #29 loop precondition). Other occupants' messages must still forward.
+func TestDispatchRoomOwnEchoCaseInsensitive(t *testing.T) {
+	b := NewXMPPBridge(ResolvedAccount{Nick: "pi", Rooms: []string{"team@muc.x.com"}}, nil, nil)
+	b.selfNick = map[string]string{"team@muc.x.com": "pi"}
+	var got []InboundMessage
+	b.onMsg = func(m InboundMessage) { got = append(got, m) }
+
+	for _, from := range []string{
+		"team@muc.x.com/pi",    // own nick, exact case (server-confirmed)
+		"team@muc.x.com/Pi",    // differently-cased resource — must still drop
+		"team@muc.x.com/PI",    // all-caps variant
+		"team@muc.x.com/peppy", // another occupant forwards
+	} {
+		b.dispatchRoom(incomingMsg{typ: "groupchat", from: from, body: "pi: hello"})
+	}
+	if len(got) != 1 || got[0].Nick != "peppy" {
+		t.Fatalf("dispatchRoom forwarded %d messages (want only peppy): %+v", len(got), got)
+	}
+}
+
+// TestDispatchRoomOwnEchoFallsBackToAccountNick covers the pre-110 window where
+// the server-confirmed nick is unknown and ownNick falls back to the configured
+// account nick.
+func TestDispatchRoomOwnEchoFallsBackToAccountNick(t *testing.T) {
+	b := NewXMPPBridge(ResolvedAccount{Nick: "pi", Rooms: []string{"team@muc.x.com"}}, nil, nil) // selfNick unset
+	var got []InboundMessage
+	b.onMsg = func(m InboundMessage) { got = append(got, m) }
+	b.dispatchRoom(incomingMsg{typ: "groupchat", from: "team@muc.x.com/Pi", body: "anything"})
+	if len(got) != 0 {
+		t.Fatalf("own-echo from fallback nick forwarded: %+v", got)
+	}
+}


### PR DESCRIPTION
Closes #29

The MUC own-echo guard compared nicks byte-wise (`==`), so a server echoing a differently-cased resource — XMPP nick matching is case-folded in principle — slipped past it. A miss lets our own message re-enter `classify`; since agents routinely write their own handle, `matchTrigger` matches → `actionCommentary` → the agent prompts itself → loop.

## Changes

- **`xmpp.go` `dispatchRoom`** — own-echo guard now uses `strings.EqualFold(nick, b.ownNick(room))`.
- **`bridge.go` `handleRoom`** — defence in depth: drops any room message whose sender nick matches our own regardless of how it arrived (covers live + replayed paths), and logs a warning on the drop since it indicates the transport guard failed.
- **Tests** — case-variant echoes (`pi`/`Pi`/`PI`) dropped at transport and dispatch level; pre-110 fallback-nick window covered; other occupants' messages still forward.

## Verification

`go build`, `go vet`, and the full `go test ./...` suite pass. New tests: `TestDispatchRoomOwnEchoCaseInsensitive`, `TestDispatchRoomOwnEchoFallsBackToAccountNick`, `TestHandleRoomDropsOwnEcho`.

Note: pi-msg is infra (fleet XMPP bridges, no repo-scoped staging env) — per contract no live-test artifact applies; the deploy path is nix-config, outside my lane.