### PR TITLE
fix: run post-/new OpenRouter credit check off the event loop

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -900,8 +900,11 @@ func (b *Bridge) handleCommand(t string) bool {
 		b.reportResult(err, res, "🆕 new session ready", "/new")
 		if err == nil {
 			// /new also reports OpenRouter credit when a creditWatch floor is
-			// configured (see reportCreditIfWatched).
-			b.reportCreditIfWatched()
+			// configured (see reportCreditIfWatched). It's diagnostic only —
+			// fetch it off the event loop so a slow credits endpoint can't
+			// stall /new's cleanup (session file refresh, routing re-seed) or
+			// block queued inbound messages behind the handler.
+			go b.reportCreditIfWatched()
 			// /new swaps to a brand-new session, but pi does NOT emit a
 			// session_start event over the RPC stream (it's a lifecycle hook the
 			// extension sees via pi.on(), not an event the bridge receives — the


### PR DESCRIPTION
## What

`reportCreditIfWatched()` — the diagnostic OpenRouter low-credit DM after `/new` — now runs in a goroutine instead of synchronously inside the `/new` command handler.

## Why

The credits fetch is diagnostic only but blocked the handler: `http.Client{Timeout: 15s}` against `openrouter.ai/api/v1/credits` stalled `/new`'s cleanup (`refreshSessionFile`, `routingSeeded` reset) and blocked queued inbound messages behind the handler on the XMPP read goroutine.

## Notes

- Only fires when `MinCreditUsd > 0` is configured and pi's OpenRouter key is discoverable; silent above the floor.
- The proactive hourly watcher (`maybeCheckCredits`) is unaffected — it already runs on the idleWatcher background goroutine.
- `reply`/`log` are already goroutine-safe (precedent: the send_file relay goroutine).

## Verification

`go build`, `go vet`, `go test ./...` all pass.