### PR TITLE
feat: bare ! interrupts without flushing the queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,14 +79,17 @@ sequenceDiagram
 | `/session` | session stats — id, file, message counts, tokens, cost (no LLM turn) |
 | `/name [name]` | show the session display name, or set it |
 | `/think <off\|low\|medium\|high\|…>` | `set_thinking_level` |
-| `/abort` (or `/stop`, or a lone `!`) | `clear_queue`, then `abort` — the queue drain stops a steer that landed mid-run from starting a fresh run the instant the aborted one stops. The reply names how many queued messages it dropped. |
+| `/abort` (or `/stop`) | `clear_queue`, then `abort` — stops the run AND flushes pi's queued messages: a steer that landed mid-run can't start a fresh run the instant the aborted one stops. The reply names how many queued messages it dropped. |
+| `!` | `abort` only — the quick interrupt. Stops whatever is currently running (a command or thinking) but leaves queued messages intact, so the next one is evaluated right after. |
 | `/dump` (or `/dump pretty`) | send the session transcript to the owner — raw JSONL, or `pretty` for indented per-record JSON (no LLM turn) |
 | `/export` | render the current session to HTML via pi's `export_html` RPC and **send it as a file over XMPP** (XEP-0363 HTTP Upload) — **deterministic**, no agent turn; the rendered session lands as an inline, downloadable file |
 | `/quit` (or `/exit`) | shut down the bridge and Pi |
 
 Every bridged command also works with a `!` prefix — `/new` and `!new` are
-interchangeable. A lone `!` (no command name after it) is shorthand for
-`/abort`. The prefix only matters for the owner: non-owners' messages
+interchangeable. A lone `!` (no command name after it) is the quick
+interrupt: it aborts the current run like `/abort`, but WITHOUT the queue
+flush — whatever you queued behind the running message is still evaluated
+next. The prefix only matters for the owner: non-owners' messages
 are always treated as literal text.
 
 ## Configuration

--- a/bridge.go
+++ b/bridge.go
@@ -883,12 +883,15 @@ func (b *Bridge) dispatchCommentary(body, nick, origin, sender, reactTo, reactID
 // caller forwards it to pi as a prompt.
 func (b *Bridge) handleCommand(t string) bool {
 	name, arg := splitCommand(t)
-	// A lone "!" is shorthand for /abort: with no command name after the
-	// prefix it would otherwise fall through to pi as a degenerate literal
-	// prompt (an empty control command). "!abort", "!new" etc. already work
-	// through splitCommand's prefix alias.
+	// A lone "!" is the quick interrupt — deliberately NOT /abort. With no
+	// command name after the prefix it would otherwise fall through to pi as a
+	// degenerate literal prompt (an empty control command); instead it only
+	// stops whatever is currently running (a command or thinking) and leaves
+	// pi's queued messages intact, so the next one evaluates the moment the
+	// aborted run stops. "!abort", "!new" etc. still work through
+	// splitCommand's prefix alias, and keep their /-equivalent behaviour.
 	if t == "!" {
-		name = "abort"
+		name = "interrupt"
 	}
 	switch name {
 	case "new":
@@ -946,6 +949,15 @@ func (b *Bridge) handleCommand(t string) bool {
 			msg += fmt.Sprintf(" (%d queued messages dropped)", dropped)
 		}
 		b.reply(msg)
+	case "interrupt":
+		// Bare "!": stop the current command/thinking WITHOUT flushing the
+		// queue. Only the abort RPC is sent — clear_queue is what drops
+		// queued steers/follow-ups, and only /abort asks for that, so pi
+		// evaluates the next queued message as soon as the abort lands.
+		b.rpc.Abort()
+		b.settleLocally()
+		b.lifecycleReact("⏹") // interrupted
+		b.reply("⏹ interrupted — continuing with the next queued message")
 	case "quit", "exit":
 		b.shutdown("requested over chat")
 	case "dump":

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -62,24 +62,25 @@ func TestSplitCommand(t *testing.T) {
 	}
 }
 
-// TestBareBangIsAbort verifies a lone "!" maps to the abort path, not a
-// literal prompt: splitCommand yields an empty name, which handleCommand's
-// special case turns into "abort" (without it, the empty name falls through
-// the default as text). Non-bang inputs are unmodified.
-func TestBareBangIsAbort(t *testing.T) {
+// TestBareBangIsInterrupt verifies a lone "!" maps to the interrupt path
+// (abort WITHOUT the queue flush), not a literal prompt and not /abort:
+// splitCommand yields an empty name, which handleCommand's special case turns
+// into "interrupt" (without it, the empty name falls through the default as
+// text). Non-bang inputs are unmodified; "!abort" stays the /abort alias.
+func TestBareBangIsInterrupt(t *testing.T) {
 	cases := []struct {
 		in   string
 		name string
 	}{
-		{"!", "abort"},  // lone bang → handleCommand maps to abort
-		{"!!", "!"},     // two bangs → name "!", falls through as text
-		{"! abort", ""}, // space after bang → empty name, falls through
+		{"!", "interrupt"}, // lone bang → handleCommand maps to interrupt, not abort
+		{"!!", "!"},        // two bangs → name "!", falls through as text
+		{"! abort", ""},    // space after bang → empty name, falls through
 		{"!abort", "abort"},
 	}
 	for _, c := range cases {
 		name, _ := splitCommand(c.in)
 		if c.in == "!" {
-			name = "abort" // the handleCommand special case under test
+			name = "interrupt" // the handleCommand special case under test
 		}
 		if name != c.name {
 			t.Errorf("command for %q → %q, want %q", c.in, name, c.name)


### PR DESCRIPTION
## What

`/abort` and a bare `!` are no longer synonyms:

| Command | Behaviour |
|---|---|
| `/abort` (or `/stop`) | `clear_queue`, then `abort` — stops the run **and flushes** pi's queued messages |
| `!` | `abort` only — stops the current command/thinking, leaves queued messages intact |

A lone `!` previously mapped to `/abort` (via `handleCommand`'s special case), so
every interrupt also drained pi's steering/follow-up queues — you could not stop
a runaway tool or thinking pass and still have the messages you queued behind it
evaluated. There was no way to get "stop, then continue with the next message".

## Why

Zach's spec: **/abort stops and flushes the message queue; ! just stops whatever
is going on (command, thinking) and forces eval of the next message in queue.**

Pi's RPC surface already supports both halves: `abort` stops the current run
while the queue survives (pi starts a fresh run the moment the aborted one
stops), and `clear_queue` is what actually drops queued steers/follow-ups.
`/abort` keeps sending both; bare `!` now sends only `abort`.

`!abort` / `!stop` keep their documented alias behaviour (`!<cmd>` = `/<cmd>`);
only the bare `!` changes.

## Changes

- `bridge.go` — new `interrupt` command for bare `!` (abort RPC only, settle
  locally, replies `⏹ interrupted — continuing with the next queued message`);
  `/abort`/`/stop` unchanged (drain queue, then abort).
- `bridge_test.go` — `TestBareBangIsAbort` → `TestBareBangIsInterrupt`, pins
  `!` → `interrupt` and `!abort` → `abort`.
- `README.md` — documents both rows and the lone-`!` semantics.

Tests: full `go test` suite passes (incl. `TestBareBangIsInterrupt`,
`TestClearQueueCounts`), `go vet` clean.