### PR TITLE
Drop periodic low-credit watcher — warn on /new only

### DIFF
--- a/bridge.go
+++ b/bridge.go
@@ -21,15 +21,6 @@ import (
 // it (~30s), so the typing indicator stays lit while the agent works.
 const typingRefresh = 20 * time.Second
 
-// creditCheckInterval is how often the proactive low-credit watcher probes the
-// OpenRouter balance (see maybeCheckCredits).
-const creditCheckInterval = time.Hour
-
-// creditReWarnDelay is the minimum gap between low-credit DMs to the owner
-// while the balance stays below the floor, so a dry spell nags without
-// spamming.
-const creditReWarnDelay = 6 * time.Hour
-
 // Bridge wires an XMPP connection to a `pi --mode rpc` child: owner chat
 // becomes pi commands, and pi's events become chat replies / presence /
 // typing.
@@ -102,16 +93,12 @@ type Bridge struct {
 	// must never be hinted about in turn: the agent has just been asked to catch
 	// up, so whatever it sends IS the catch-up. Hinting again would ask it to
 	// check its own correction, and could do so for as long as the budget lasts.
-	hintPending    bool
-	idleSince      time.Time // when the agent last became idle; zero while a run is in flight
-	awayAnnounced  bool      // the away transition has been announced this idle period
-	lastAwayStatus string    // the last pithy activity shown while away (skip repeats across periods)
-	bgProcesses    int       // background processes pi has running (relayed by the pi-processes extension)
-	pendingHeartbeats []string // long-running-process alarms queued while a run was in flight
-
-	// Periodic low-credit watcher state (see maybeCheckCredits).
-	lastCreditProbe time.Time // when the balance endpoint was last hit
-	lastCreditWarn  time.Time // when the owner was last DMed about low credit
+	hintPending       bool
+	idleSince         time.Time // when the agent last became idle; zero while a run is in flight
+	awayAnnounced     bool      // the away transition has been announced this idle period
+	lastAwayStatus    string    // the last pithy activity shown while away (skip repeats across periods)
+	bgProcesses       int       // background processes pi has running (relayed by the pi-processes extension)
+	pendingHeartbeats []string  // long-running-process alarms queued while a run was in flight
 
 	lifecycleReactTo string // snapshot of reactTo at run start, for lifecycle auto-reacts
 	lifecycleReactID string // snapshot of reactID at run start; never overwritten by deliverReply
@@ -2556,51 +2543,7 @@ func (b *Bridge) reportCreditIfWatched() {
 	b.reply(lowCreditText(remaining, b.acct.MinCreditUsd))
 }
 
-// maybeCheckCredits is the proactive low-credit watcher, called from idleTick.
-// Every creditCheckInterval it probes the OpenRouter balance and DMs the owner
-// when it sits below the creditWatch floor. This closes the gap that bit Zach:
-// reportCreditIfWatched only fires on /new, so a balance that dropped below the
-// floor mid-session was never reported — until a 402 killed a run outright.
-// Re-warns at most once per creditReWarnDelay while still below the floor.
-func (b *Bridge) maybeCheckCredits() {
-	if b.acct.MinCreditUsd <= 0 {
-		return
-	}
-	key := openRouterKey()
-	if key == "" {
-		return
-	}
-	b.mu.Lock()
-	if time.Since(b.lastCreditProbe) < creditCheckInterval {
-		b.mu.Unlock()
-		return
-	}
-	b.lastCreditProbe = time.Now()
-	b.mu.Unlock()
-
-	total, used, err := openRouterCredits(key)
-	if err != nil {
-		b.log("warning", "periodic credit check failed: "+err.Error())
-		return
-	}
-	remaining := total - used
-	if remaining >= b.acct.MinCreditUsd {
-		return
-	}
-	b.mu.Lock()
-	rearm := time.Since(b.lastCreditWarn) >= creditReWarnDelay
-	if rearm {
-		b.lastCreditWarn = time.Now()
-	}
-	b.mu.Unlock()
-	if !rearm {
-		return
-	}
-	b.reply(lowCreditText(remaining, b.acct.MinCreditUsd))
-}
-
-// lowCreditText renders the below-floor credit alert shared by the /new report
-// and the periodic watcher.
+// lowCreditText renders the below-floor credit alert used by the /new report.
 func lowCreditText(remaining, floor float64) string {
 	return fmt.Sprintf("⚠️ OpenRouter credit: $%.2f remaining — below your $%.2f floor, reload soon", remaining, floor)
 }
@@ -3144,8 +3087,6 @@ func (b *Bridge) idleWatcher(ctx context.Context) {
 // once per idle period, once the agent has been idle past idleAwayTimeout.
 // Split out from idleWatcher so it's callable directly from tests.
 func (b *Bridge) idleTick() {
-	b.maybeCheckCredits()
-
 	b.mu.Lock()
 	idle := !b.idleSince.IsZero()
 	elapsed := time.Since(b.idleSince)

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -5,12 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"encoding/xml"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -1529,89 +1526,5 @@ func TestNonCreditErrorUnchanged(t *testing.T) {
 	b.handleRPCEvent(ev)
 	if b.replied() {
 		t.Error("non-credit error must not mark the run replied; the no-reply nudge should still apply")
-	}
-}
-
-// maybeCheckCredits probes at most once per creditCheckInterval, DMs the owner
-// when the balance is below the floor, and re-warns at most once per
-// creditReWarnDelay while still below.
-func TestMaybeCheckCredits(t *testing.T) {
-	// Point openRouterKey at a temp auth file.
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{"openrouter":{"key":"sk-or-test"}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PI_CODING_AGENT_DIR", dir)
-
-	// Stub the credits endpoint, counting hits. remaining is mutable so the
-	// same server can answer both below- and above-floor states.
-	var (
-		hitsMu    sync.Mutex
-		hits      int
-		remaining = 2.0 // below the $5 floor
-	)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		hitsMu.Lock()
-		hits++
-		hitsMu.Unlock()
-		w.Header().Set("Content-Type", "application/json")
-		io.WriteString(w, fmt.Sprintf(`{"data":{"total_credits":10,"total_usage":%v}}`, 10-remaining))
-	}))
-	defer srv.Close()
-	orig := creditEndpoint
-	creditEndpoint = srv.URL
-	defer func() { creditEndpoint = orig }()
-
-	b := roomBridge()
-	b.xmpp = NewXMPPBridge(b.acct, func(InboundMessage) {}, func(_, _ string) {})
-	b.acct.MinCreditUsd = 5
-
-	b.maybeCheckCredits()
-	if b.lastCreditWarn.IsZero() {
-		t.Fatal("below-floor balance should warn the owner on the first probe")
-	}
-	warn1 := b.lastCreditWarn
-
-	// Immediate re-call: interval gate suppresses another probe/warn.
-	b.maybeCheckCredits()
-	if !b.lastCreditWarn.Equal(warn1) {
-		t.Error("re-warn fired inside creditCheckInterval")
-	}
-	b.mu.Lock()
-	hitsNow := hits
-	b.mu.Unlock()
-	if hitsNow != 1 {
-		t.Errorf("endpoint hit %d times in one interval, want 1", hitsNow)
-	}
-
-	// Above the floor: a fresh probe must not warn.
-	remaining = 8                   // $8 remaining > $5 floor
-	b.lastCreditProbe = time.Time{} // force a fresh probe
-	b.lastCreditWarn = time.Time{}
-	b.maybeCheckCredits()
-	if !b.lastCreditWarn.IsZero() {
-		t.Error("above-floor balance must not warn")
-	}
-}
-
-// Accounts without a creditWatch floor must never probe the endpoint at all.
-func TestMaybeCheckCreditsNoFloor(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "auth.json"), []byte(`{"openrouter":{"key":"sk-or-test"}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PI_CODING_AGENT_DIR", dir)
-
-	hits := 0
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { hits++ }))
-	defer srv.Close()
-	orig := creditEndpoint
-	creditEndpoint = srv.URL
-	defer func() { creditEndpoint = orig }()
-
-	b := roomBridge() // MinCreditUsd = 0
-	b.maybeCheckCredits()
-	if hits != 0 {
-		t.Errorf("endpoint hit %d times with no floor configured, want 0", hits)
 	}
 }


### PR DESCRIPTION
Removes the proactive OpenRouter low-credit watcher that ran off the 30s idle ticker.

**Why:** every bridge shares one OpenRouter balance + key, so the hourly probe fired the ⚠️ credit DM from all agents simultaneously; below-floor balances also nagged every 6h. The `/new` report already covers the use case — a credit heads-up exactly when a fresh session is started.

**Changes:**
- Delete `maybeCheckCredits`, `creditCheckInterval`, `creditReWarnDelay`, the per-bridge probe/warn state, and the `idleTick` call
- Keep `reportCreditIfWatched` (the `/new` path) and `lowCreditText`
- Drop the two now-dead tests and their now-unused imports

**Verified:** `go build`, `go vet`, full `go test ./...` pass.

Deploy = bridge restart; left to Zach's timing (config already points at deepseek-v4.1-flash for the next restart).